### PR TITLE
Tags refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## MASTER
+
+* Moved from generic _tag_ parameter on container to `Tag` enum with `String` and `Int` cases ([#3](https://github.com/AliSoftware/Dip/pull/3), [@ilyapuchka](https://github.com/ilyapuchka))
+
 ## 1.0.1
 
 * Improved README

--- a/Example/DipSampleApp/DependencyContainers.swift
+++ b/Example/DipSampleApp/DependencyContainers.swift
@@ -27,8 +27,8 @@ let wsDependencies = DependencyContainer() { dip in
 }
 
 
-let NamedStarshipProviderTag    = Tag.String("NamedStarshipProvider")
-let PlistPersonProviderTag      = Tag.String("PlistPersonProvider")
+let NamedStarshipProviderTag: Tag    = "NamedStarshipProvider"
+let PlistPersonProviderTag: Tag      = "PlistPersonProvider"
 
 // MARK: Dependency Container for Providers
 let providerDependencies = DependencyContainer() { dip in

--- a/Example/DipSampleApp/DependencyContainers.swift
+++ b/Example/DipSampleApp/DependencyContainers.swift
@@ -27,8 +27,8 @@ let wsDependencies = DependencyContainer() { dip in
 }
 
 
-let NamedStarshipProviderTag    = "NamedStarshipProvider"
-let PlistPersonProviderTag      = "PlistPersonProvider"
+let NamedStarshipProviderTag    = Tag.String("NamedStarshipProvider")
+let PlistPersonProviderTag      = Tag.String("PlistPersonProvider")
 
 // MARK: Dependency Container for Providers
 let providerDependencies = DependencyContainer() { dip in

--- a/Example/DipSampleApp/DependencyContainers.swift
+++ b/Example/DipSampleApp/DependencyContainers.swift
@@ -19,7 +19,7 @@ private let FAKE_STARSHIPS = false
 
 
 // MARK: Dependency Container for WebServices & NetworkLayer
-let wsDependencies = DependencyContainer<WebService>() { dip in
+let wsDependencies = DependencyContainer() { dip in
     
     // Register the NetworkLayer, same for everyone here (but we have the ability to register a different one for a specific WebService if we wanted to)
     dip.register(instance: URLSessionNetworkLayer(baseURL: "http://swapi.co/api/")! as NetworkLayer)
@@ -27,15 +27,17 @@ let wsDependencies = DependencyContainer<WebService>() { dip in
 }
 
 
+let NamedStarshipProviderTag    = "NamedStarshipProvider"
+let PlistPersonProviderTag      = "PlistPersonProvider"
 
 // MARK: Dependency Container for Providers
-let providerDependencies = DependencyContainer<Int>() { dip in
+let providerDependencies = DependencyContainer() { dip in
     
     if FAKE_PERSONS {
         
         // 1) Register the PersonProviderAPI singleton, one generic and one specific for a specific personID
         dip.register(instance: DummyPilotProvider() as PersonProviderAPI)
-        dip.register(0, instance: PlistPersonProvider(plist: "mainPilot") as PersonProviderAPI)
+        dip.register(PlistPersonProviderTag, instance: PlistPersonProvider(plist: "mainPilot") as PersonProviderAPI)
         
     } else {
         
@@ -48,7 +50,7 @@ let providerDependencies = DependencyContainer<Int>() { dip in
 
         // 2) Register the StarshipProviderAPI factories, one generic and one specific for a specific starshipID
         dip.register() { HardCodedStarshipProvider() as StarshipProviderAPI }
-        dip.register(0) { DummyStarshipProvider(pilotName: "Main Pilot") as StarshipProviderAPI }
+        dip.register(NamedStarshipProviderTag) { DummyStarshipProvider(pilotName: "Main Pilot") as StarshipProviderAPI }
         
     } else {
         

--- a/Example/DipSampleApp/DependencyContainers.swift
+++ b/Example/DipSampleApp/DependencyContainers.swift
@@ -27,9 +27,6 @@ let wsDependencies = DependencyContainer() { dip in
 }
 
 
-let NamedStarshipProviderTag: Tag    = "NamedStarshipProvider"
-let PlistPersonProviderTag: Tag      = "PlistPersonProvider"
-
 // MARK: Dependency Container for Providers
 let providerDependencies = DependencyContainer() { dip in
     
@@ -37,7 +34,7 @@ let providerDependencies = DependencyContainer() { dip in
         
         // 1) Register the PersonProviderAPI singleton, one generic and one specific for a specific personID
         dip.register(instance: DummyPilotProvider() as PersonProviderAPI)
-        dip.register(PlistPersonProviderTag, instance: PlistPersonProvider(plist: "mainPilot") as PersonProviderAPI)
+        dip.register(0, instance: PlistPersonProvider(plist: "mainPilot") as PersonProviderAPI)
         
     } else {
         
@@ -50,7 +47,7 @@ let providerDependencies = DependencyContainer() { dip in
 
         // 2) Register the StarshipProviderAPI factories, one generic and one specific for a specific starshipID
         dip.register() { HardCodedStarshipProvider() as StarshipProviderAPI }
-        dip.register(NamedStarshipProviderTag) { DummyStarshipProvider(pilotName: "Main Pilot") as StarshipProviderAPI }
+        dip.register(0) { DummyStarshipProvider(pilotName: "Main Pilot") as StarshipProviderAPI }
         
     } else {
         

--- a/Example/DipSampleApp/Providers/SWAPICommon.swift
+++ b/Example/DipSampleApp/Providers/SWAPICommon.swift
@@ -7,14 +7,16 @@
 //
 
 import Foundation
+import Dip
 
 enum SWAPIError: ErrorType {
     case InvalidJSON
 }
 
-enum WebService {
+enum WebService: String {
     case PersonWS
     case StarshipWS
+    var tag: Tag { return Tag.String(self.rawValue) }
 }
 
 func idFromURLString(urlString: String) -> Int? {

--- a/Example/DipSampleApp/Providers/SWAPIPersonProvider.swift
+++ b/Example/DipSampleApp/Providers/SWAPIPersonProvider.swift
@@ -7,12 +7,9 @@
 //
 
 import Foundation
-import Dip
-
-let PersonWebServiceTag: Tag = "PersonWS"
 
 struct SWAPIPersonProvider : PersonProviderAPI {
-    let ws = wsDependencies.resolve(PersonWebServiceTag) as NetworkLayer
+    let ws = wsDependencies.resolve(WebService.PersonWS.tag) as NetworkLayer
     
     func fetchIDs(completion: [Int] -> Void) {
         ws.request("people") { response in

--- a/Example/DipSampleApp/Providers/SWAPIPersonProvider.swift
+++ b/Example/DipSampleApp/Providers/SWAPIPersonProvider.swift
@@ -7,8 +7,9 @@
 //
 
 import Foundation
+import Dip
 
-let PersonWebServiceTag = "PersonWS"
+let PersonWebServiceTag = Tag.String("PersonWS")
 
 struct SWAPIPersonProvider : PersonProviderAPI {
     let ws = wsDependencies.resolve(PersonWebServiceTag) as NetworkLayer

--- a/Example/DipSampleApp/Providers/SWAPIPersonProvider.swift
+++ b/Example/DipSampleApp/Providers/SWAPIPersonProvider.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Dip
 
-let PersonWebServiceTag = Tag.String("PersonWS")
+let PersonWebServiceTag: Tag = "PersonWS"
 
 struct SWAPIPersonProvider : PersonProviderAPI {
     let ws = wsDependencies.resolve(PersonWebServiceTag) as NetworkLayer

--- a/Example/DipSampleApp/Providers/SWAPIPersonProvider.swift
+++ b/Example/DipSampleApp/Providers/SWAPIPersonProvider.swift
@@ -8,8 +8,10 @@
 
 import Foundation
 
+let PersonWebServiceTag = "PersonWS"
+
 struct SWAPIPersonProvider : PersonProviderAPI {
-    let ws = wsDependencies.resolve(.PersonWS) as NetworkLayer
+    let ws = wsDependencies.resolve(PersonWebServiceTag) as NetworkLayer
     
     func fetchIDs(completion: [Int] -> Void) {
         ws.request("people") { response in

--- a/Example/DipSampleApp/Providers/SWAPIStarshipProvider.swift
+++ b/Example/DipSampleApp/Providers/SWAPIStarshipProvider.swift
@@ -8,8 +8,10 @@
 
 import Foundation
 
+let StarshipWebServiceTag = "StarshipWS"
+
 struct SWAPIStarshipProvider : StarshipProviderAPI {
-    let ws = wsDependencies.resolve(.StarshipWS) as NetworkLayer
+    let ws = wsDependencies.resolve(StarshipWebServiceTag) as NetworkLayer
     
     func fetchIDs(completion: [Int] -> Void) {
         ws.request("starships") { response in

--- a/Example/DipSampleApp/Providers/SWAPIStarshipProvider.swift
+++ b/Example/DipSampleApp/Providers/SWAPIStarshipProvider.swift
@@ -7,12 +7,9 @@
 //
 
 import Foundation
-import Dip
-
-let StarshipWebServiceTag: Tag = "StarshipWS"
 
 struct SWAPIStarshipProvider : StarshipProviderAPI {
-    let ws = wsDependencies.resolve(StarshipWebServiceTag) as NetworkLayer
+    let ws = wsDependencies.resolve(WebService.StarshipWS.tag) as NetworkLayer
     
     func fetchIDs(completion: [Int] -> Void) {
         ws.request("starships") { response in

--- a/Example/DipSampleApp/Providers/SWAPIStarshipProvider.swift
+++ b/Example/DipSampleApp/Providers/SWAPIStarshipProvider.swift
@@ -7,8 +7,9 @@
 //
 
 import Foundation
+import Dip
 
-let StarshipWebServiceTag = "StarshipWS"
+let StarshipWebServiceTag = Tag.String("StarshipWS")
 
 struct SWAPIStarshipProvider : StarshipProviderAPI {
     let ws = wsDependencies.resolve(StarshipWebServiceTag) as NetworkLayer

--- a/Example/DipSampleApp/Providers/SWAPIStarshipProvider.swift
+++ b/Example/DipSampleApp/Providers/SWAPIStarshipProvider.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Dip
 
-let StarshipWebServiceTag = Tag.String("StarshipWS")
+let StarshipWebServiceTag: Tag = "StarshipWS"
 
 struct SWAPIStarshipProvider : StarshipProviderAPI {
     let ws = wsDependencies.resolve(StarshipWebServiceTag) as NetworkLayer

--- a/Example/DipSampleApp/ViewControllers/PersonListViewController.swift
+++ b/Example/DipSampleApp/ViewControllers/PersonListViewController.swift
@@ -17,7 +17,7 @@ class PersonListViewController: UITableViewController, FetchableTrait {
         return provider.fetchIDs(completion)
     }
     func fetchOne(personID: Int, completion: Person? -> Void) {
-        let provider = providerDependencies.resolve("\(personID)") as PersonProviderAPI
+        let provider = providerDependencies.resolve(.Int(personID)) as PersonProviderAPI
         return provider.fetch(personID, completion: completion)
     }
     

--- a/Example/DipSampleApp/ViewControllers/PersonListViewController.swift
+++ b/Example/DipSampleApp/ViewControllers/PersonListViewController.swift
@@ -17,7 +17,7 @@ class PersonListViewController: UITableViewController, FetchableTrait {
         return provider.fetchIDs(completion)
     }
     func fetchOne(personID: Int, completion: Person? -> Void) {
-        let provider = providerDependencies.resolve(personID) as PersonProviderAPI
+        let provider = providerDependencies.resolve("\(personID)") as PersonProviderAPI
         return provider.fetch(personID, completion: completion)
     }
     

--- a/Example/DipSampleApp/ViewControllers/StarshipListViewController.swift
+++ b/Example/DipSampleApp/ViewControllers/StarshipListViewController.swift
@@ -7,13 +7,14 @@
 //
 
 import UIKit
+import Dip
 
 class StarshipListViewController : UITableViewController, FetchableTrait {
     var objects: [Starship]?
     var batchRequestID = 0
     
     private func provider(tag:Int?) -> StarshipProviderAPI {
-        return providerDependencies.resolve( tag != nil ? .Int(tag!) : nil)
+        return providerDependencies.resolve(tag.flatMap { .Int($0) })
     }
     
     func fetchIDs(completion: [Int] -> Void) {

--- a/Example/DipSampleApp/ViewControllers/StarshipListViewController.swift
+++ b/Example/DipSampleApp/ViewControllers/StarshipListViewController.swift
@@ -12,7 +12,7 @@ class StarshipListViewController : UITableViewController, FetchableTrait {
     var objects: [Starship]?
     var batchRequestID = 0
     
-    private func provider(tag:Int?) -> StarshipProviderAPI { return providerDependencies.resolve(tag) }
+    private func provider(tag:Int?) -> StarshipProviderAPI { return providerDependencies.resolve("\(tag)") }
     
     func fetchIDs(completion: [Int] -> Void) {
         provider(nil).fetchIDs(completion)

--- a/Example/DipSampleApp/ViewControllers/StarshipListViewController.swift
+++ b/Example/DipSampleApp/ViewControllers/StarshipListViewController.swift
@@ -12,7 +12,9 @@ class StarshipListViewController : UITableViewController, FetchableTrait {
     var objects: [Starship]?
     var batchRequestID = 0
     
-    private func provider(tag:Int?) -> StarshipProviderAPI { return providerDependencies.resolve("\(tag)") }
+    private func provider(tag:Int?) -> StarshipProviderAPI {
+        return providerDependencies.resolve( tag != nil ? .Int(tag!) : nil)
+    }
     
     func fetchIDs(completion: [Int] -> Void) {
         provider(nil).fetchIDs(completion)

--- a/Example/Tests/NetworkMock.swift
+++ b/Example/Tests/NetworkMock.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Dip
 
-var wsDependencies = DependencyContainer<WebService>()
+var wsDependencies = DependencyContainer()
 
 // MARK: - Mock object used for tests
 

--- a/Example/Tests/SWAPIPersonProviderTests.swift
+++ b/Example/Tests/SWAPIPersonProviderTests.swift
@@ -22,7 +22,7 @@ class SWAPIPersonProviderTests: XCTestCase {
     
     func testFetchPersonIDs() {
         let mock = NetworkMock(json: ["results": [fakePerson1, fakePerson2]])
-        wsDependencies.register(.PersonWS, instance: mock as NetworkLayer)
+        wsDependencies.register(PersonWebServiceTag, instance: mock as NetworkLayer)
         
         let provider = SWAPIPersonProvider()
         provider.fetchIDs { personIDs in
@@ -37,7 +37,7 @@ class SWAPIPersonProviderTests: XCTestCase {
     func testFetchOnePerson() {
         
         let mock = NetworkMock(json: fakePerson1)
-        wsDependencies.register(.PersonWS, instance: mock as NetworkLayer)
+        wsDependencies.register(PersonWebServiceTag, instance: mock as NetworkLayer)
         
         let provider = SWAPIPersonProvider()
         provider.fetch(1) { person in
@@ -57,7 +57,7 @@ class SWAPIPersonProviderTests: XCTestCase {
     func testFetchInvalidPerson() {
         let json = ["error":"whoops"]
         let mock = NetworkMock(json: json)
-        wsDependencies.register(.PersonWS, instance: mock as NetworkLayer)
+        wsDependencies.register(PersonWebServiceTag, instance: mock as NetworkLayer)
         
         let provider = SWAPIPersonProvider()
         provider.fetch(12) { person in

--- a/Example/Tests/SWAPIPersonProviderTests.swift
+++ b/Example/Tests/SWAPIPersonProviderTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import Dip
 
 class SWAPIPersonProviderTests: XCTestCase {
     let fakePerson1 = ["name": "John Doe", "mass": "72", "height": "172", "eye_color": "brown", "hair_color": "black", "gender": "male",
@@ -22,7 +23,7 @@ class SWAPIPersonProviderTests: XCTestCase {
     
     func testFetchPersonIDs() {
         let mock = NetworkMock(json: ["results": [fakePerson1, fakePerson2]])
-        wsDependencies.register(PersonWebServiceTag, instance: mock as NetworkLayer)
+        wsDependencies.register(WebService.PersonWS.tag, instance: mock as NetworkLayer)
         
         let provider = SWAPIPersonProvider()
         provider.fetchIDs { personIDs in
@@ -37,7 +38,7 @@ class SWAPIPersonProviderTests: XCTestCase {
     func testFetchOnePerson() {
         
         let mock = NetworkMock(json: fakePerson1)
-        wsDependencies.register(PersonWebServiceTag, instance: mock as NetworkLayer)
+        wsDependencies.register(WebService.PersonWS.tag, instance: mock as NetworkLayer)
         
         let provider = SWAPIPersonProvider()
         provider.fetch(1) { person in
@@ -57,7 +58,7 @@ class SWAPIPersonProviderTests: XCTestCase {
     func testFetchInvalidPerson() {
         let json = ["error":"whoops"]
         let mock = NetworkMock(json: json)
-        wsDependencies.register(PersonWebServiceTag, instance: mock as NetworkLayer)
+        wsDependencies.register(WebService.PersonWS.tag, instance: mock as NetworkLayer)
         
         let provider = SWAPIPersonProvider()
         provider.fetch(12) { person in

--- a/Example/Tests/SWAPIStarshipProviderTests.swift
+++ b/Example/Tests/SWAPIStarshipProviderTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import Dip
 
 class SWAPIStarshipProviderTests: XCTestCase {
     let fakeShip1 = ["name": "Falcon", "model": "Fighter", "manufacturer": "Fake Industries", "crew": "7", "passengers": "15",
@@ -22,7 +23,7 @@ class SWAPIStarshipProviderTests: XCTestCase {
     
     func testFetchStarshipIDs() {
         let mock = NetworkMock(json: ["results": [fakeShip1, fakeShip2]])
-        wsDependencies.register(StarshipWebServiceTag, instance: mock as NetworkLayer)
+        wsDependencies.register(WebService.StarshipWS.tag, instance: mock as NetworkLayer)
         
         let provider = SWAPIStarshipProvider()
         provider.fetchIDs { shipIDs in
@@ -37,7 +38,7 @@ class SWAPIStarshipProviderTests: XCTestCase {
     func testFetchOneStarship() {
         
         let mock = NetworkMock(json: fakeShip1)
-        wsDependencies.register(StarshipWebServiceTag, instance: mock as NetworkLayer)
+        wsDependencies.register(WebService.StarshipWS.tag, instance: mock as NetworkLayer)
         
         let provider = SWAPIStarshipProvider()
         provider.fetch(1) { starship in
@@ -56,7 +57,7 @@ class SWAPIStarshipProviderTests: XCTestCase {
     func testFetchInvalidStarship() {
         let json = ["error":"whoops"]
         let mock = NetworkMock(json: json)
-        wsDependencies.register(StarshipWebServiceTag, instance: mock as NetworkLayer)
+        wsDependencies.register(WebService.StarshipWS.tag, instance: mock as NetworkLayer)
         
         let provider = SWAPIStarshipProvider()
         provider.fetch(12) { starship in

--- a/Example/Tests/SWAPIStarshipProviderTests.swift
+++ b/Example/Tests/SWAPIStarshipProviderTests.swift
@@ -22,7 +22,7 @@ class SWAPIStarshipProviderTests: XCTestCase {
     
     func testFetchStarshipIDs() {
         let mock = NetworkMock(json: ["results": [fakeShip1, fakeShip2]])
-        wsDependencies.register(.StarshipWS, instance: mock as NetworkLayer)
+        wsDependencies.register(StarshipWebServiceTag, instance: mock as NetworkLayer)
         
         let provider = SWAPIStarshipProvider()
         provider.fetchIDs { shipIDs in
@@ -37,7 +37,7 @@ class SWAPIStarshipProviderTests: XCTestCase {
     func testFetchOneStarship() {
         
         let mock = NetworkMock(json: fakeShip1)
-        wsDependencies.register(.StarshipWS, instance: mock as NetworkLayer)
+        wsDependencies.register(StarshipWebServiceTag, instance: mock as NetworkLayer)
         
         let provider = SWAPIStarshipProvider()
         provider.fetch(1) { starship in
@@ -56,7 +56,7 @@ class SWAPIStarshipProviderTests: XCTestCase {
     func testFetchInvalidStarship() {
         let json = ["error":"whoops"]
         let mock = NetworkMock(json: json)
-        wsDependencies.register(.StarshipWS, instance: mock as NetworkLayer)
+        wsDependencies.register(StarshipWebServiceTag, instance: mock as NetworkLayer)
         
         let provider = SWAPIStarshipProvider()
         provider.fetch(12) { starship in

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ When calling the initializer of `DependencyContainer()`, you can pass a block th
 It may not seem to provide much, but given the fact that `DependencyContainers` are typically declared as global constants using a top-level `let`, it gets very useful, because instead of having to do it like this:
 
 ```swift
-let dip: DependencyContainer<String> = {
-    let dip = DependencyContainer<String>()
+let dip: DependencyContainer = {
+    let dip = DependencyContainer()
 
     dip.register(instance: ProductionEnvironment(analytics: true) as EnvironmentType)
     dip.register(instance: WebService() as WebServiceAPI)
@@ -71,10 +71,10 @@ let dip: DependencyContainer<String> = {
     }()
 ```
 
-You can instead write this exact equivalent code, which is more compact, doesn't need you to write the `DependencyContainer<TagType>` twice, and indent better in Xcode (as the final closing brack is properly aligned):
+You can instead write this exact equivalent code, which is more compact, and indent better in Xcode (as the final closing brack is properly aligned):
 
 ```swift
-let dip = DependencyContainer<String> { dip in
+let dip = DependencyContainer { dip in
     dip.register(instance: ProductionEnvironment(analytics: true) as EnvironmentType)
     dip.register(instance: WebService() as WebServiceAPI)
 }
@@ -84,21 +84,16 @@ let dip = DependencyContainer<String> { dip in
 
 * If you give a `tag` in the parameter to `register()`, it will associate that instance or factory with this tag, which can be used later during `resolve` (see below).
 * `resolve(tag)` will try to find an instance (or instance factory) that match both the requested protocol _and_ the tag. If it doesn't find any, it will fallback to an instance (or instance factory) that only match the requested protocol.
-* The tags can be anything, as long as it's of a type conforming to `Equatable`. `DependencyContainer` is a generic class which takes that type as generic parameter (so one `DependencyContainer` will be tied with a given tag type)
+* The tags can be StringLiteralType or IntegerLiteralType. That said you can use plain strings or integers as tags.
 
-For example, you can use an `Int`, a `String`… or even an `enum`, like this:
 
 ```swift
-enum WebService {
-    case PersonWS
-    case StarshipWS
-}
+let PersonWSTag: Tag = "PersonWS"
+let StashipWSTag: Tag = "StashipWS"
 
 let wsDependencies = DependencyContainer<WebService>() { dip in
-    
-    dip.register(.PersonWS, instance: URLSessionNetworkLayer(baseURL: "http://prod.myapi.com/api/")! as NetworkLayer)
-    dip.register(.StashipWS, instance: URLSessionNetworkLayer(baseURL: "http://dev.myapi.com/api/")! as NetworkLayer)
-    
+    dip.register(PersonWSTag, instance: URLSessionNetworkLayer(baseURL: "http://prod.myapi.com/api/")! as NetworkLayer)
+    dip.register(StashipWSTag, instance: URLSessionNetworkLayer(baseURL: "http://dev.myapi.com/api/")! as NetworkLayer)
 }
 ```
 
@@ -108,8 +103,8 @@ let wsDependencies = DependencyContainer<WebService>() { dip in
 Somewhere in your App target, register the dependencies:
 
 ```swift
-let dip: DependencyContainer<String> = {
-    let dip = DependencyContainer<String>()
+let dip: DependencyContainer = {
+    let dip = DependencyContainer()
     let env = ProductionEnvironment(analytics: true)
     dip.register(instance: env as EnvironmentType)
     dip.register(instance: WebService() as WebServiceType)

--- a/README.md
+++ b/README.md
@@ -88,12 +88,15 @@ let dip = DependencyContainer { dip in
 
 
 ```swift
-let PersonWSTag: Tag = "PersonWS"
-let StashipWSTag: Tag = "StashipWS"
+enum WebService: String {
+    case PersonWS
+    case StarshipWS
+    var tag: Tag { return Tag.String(self.rawValue) }
+}
 
 let wsDependencies = DependencyContainer<WebService>() { dip in
-    dip.register(PersonWSTag, instance: URLSessionNetworkLayer(baseURL: "http://prod.myapi.com/api/")! as NetworkLayer)
-    dip.register(StashipWSTag, instance: URLSessionNetworkLayer(baseURL: "http://dev.myapi.com/api/")! as NetworkLayer)
+    dip.register(WebService.PersonWS.tag, instance: URLSessionNetworkLayer(baseURL: "http://prod.myapi.com/api/")! as NetworkLayer)
+    dip.register(WebService.StashipWS.tag, instance: URLSessionNetworkLayer(baseURL: "http://dev.myapi.com/api/")! as NetworkLayer)
 }
 ```
 

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -78,7 +78,7 @@ public class DependencyContainer<TagType : Equatable> {
     
     - note: You must cast the factory return type to the protocol you want to register it with (e.g `MyClass() as MyAPI`)
     */
-    public func register<T : Any>(tag: TagType? = nil, factory: TagType?->T) {
+    public func register<T>(tag: TagType? = nil, factory: TagType?->T) {
         let key = Key(protocolType: T.self, associatedTag: tag)
         lockAndDo {
             dependencies[key] = { factory($0) }
@@ -93,7 +93,7 @@ public class DependencyContainer<TagType : Equatable> {
     
     - note: You must cast the factory return type to the protocol you want to register it with (e.g `MyClass() as MyAPI`)
     */
-    public func register<T : Any>(tag: TagType? = nil, factory: Void->T) {
+    public func register<T>(tag: TagType? = nil, factory: Void->T) {
         let key = Key(protocolType: T.self, associatedTag: tag)
         lockAndDo {
             dependencies[key] = { _ in factory() }
@@ -109,7 +109,7 @@ public class DependencyContainer<TagType : Equatable> {
     
     - note: You must cast the instance to the protocol you want to register it with (e.g `MyClass() as MyAPI`)
     */
-    public func register<T : Any>(tag: TagType? = nil, @autoclosure(escaping) instance factory: Void->T) {
+    public func register<T>(tag: TagType? = nil, @autoclosure(escaping) instance factory: Void->T) {
         let key = Key(protocolType: T.self, associatedTag: tag)
         lockAndDo {
             dependencies[key] = { _ in

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -9,8 +9,31 @@
 import Foundation
 
 public enum Tag: Equatable {
-    case String(Swift.String)
-    case Int(Swift.Int)
+    case String(StringLiteralType)
+    case Int(IntegerLiteralType)
+}
+
+extension Tag: IntegerLiteralConvertible {
+    public init(integerLiteral value: IntegerLiteralType) {
+        self = .Int(value)
+    }
+}
+
+extension Tag: StringLiteralConvertible {
+    public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
+    public typealias UnicodeScalarLiteralType = StringLiteralType
+    
+    public init(stringLiteral value: StringLiteralType) {
+        self = .String(value)
+    }
+    
+    public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
+        self.init(stringLiteral: value)
+    }
+    
+    public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
+        self.init(stringLiteral: value)
+    }
 }
 
 public func ==(lhs: Tag, rhs: Tag) -> Bool {


### PR DESCRIPTION
I noticed that at first tags were plain strings but then they changed to generics. In this pr I revert that change and here are my thoughts about that:

1. In my experience of working with DI (particularly in Obj-C with Typhoon) I've never needed named registrations. In most cases the same could be achieved by creating different containers for different environments or using runtime arguments.

2. Adding generic constraint on tag type adds type constraint on the whole container. I.e. it will be hard to add child-parent relationship between containers, or combine them in collection without introducing base protocol (what I think is useless at this point)

3. Adding generic tags limits containers flexibility and functionality. If you set it once you have to use only this type of tag inside container, so you have to move components that need other tags to other containers. It can lead to enormous number of containers. For example it make sense to group instances from network layer in one container, but that instances can have different responsibilities and it will be hard to mark them with tag of one type in context of one container, so you will end up with no tags at all or using strings or ints (ints are much less expressive than strings in that case) or you will create a lot of small containers.

4. At the end what our code can gain from using generic tags? Strings are rather expressive already. If you want safety you can always use string constants. Generics make containers code more complicated.

It would be interesting to know your motivation for moving to generic tags.