### PR TITLE
Added support for up to six runtime arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Develop
+* Added support for factories with up to six runtime arguments
+[#8](https://github.com/AliSoftware/Dip/pull/8), [@ilyapuchka](https://github.com/ilyapuchka)
+* Parameter `tag` is now named in all register/resolve methods
+
 ## 2.0.0
 
 * Moved from generic _tag_ parameter on container to `Tag` enum with `String` and `Int` cases  

--- a/Dip/Dip.xcodeproj/project.pbxproj
+++ b/Dip/Dip.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		094526B41BEA51540034E72A /* RuntimeArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094526B31BEA51540034E72A /* RuntimeArguments.swift */; };
 		094526B61BEA520B0034E72A /* Definition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094526B51BEA520B0034E72A /* Definition.swift */; };
 		094526B81BEA536A0034E72A /* RuntimeArgumentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094526B71BEA536A0034E72A /* RuntimeArgumentsTests.swift */; };
+		09969C551BEB7C0A00F93C70 /* Dip.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 09969C541BEB7C0A00F93C70 /* Dip.podspec */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,13 +35,13 @@
 		094526A01BEA1CFF0034E72A /* DipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DipTests.swift; sourceTree = "<group>"; };
 		094526A21BEA1CFF0034E72A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		094526AB1BEA1D200034E72A /* Dip.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dip.swift; sourceTree = "<group>"; };
-		094526AE1BEA1D5E0034E72A /* Dip.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = Dip.podspec; path = /Users/ilya/Documents/Developer/iPhoneProjects/Dip/Dip.podspec; sourceTree = "<absolute>"; };
 		094526B01BEA1E1C0034E72A /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		094526B11BEA1E1C0034E72A /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../CHANGELOG.md; sourceTree = "<group>"; };
 		094526B21BEA1E1C0034E72A /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		094526B31BEA51540034E72A /* RuntimeArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuntimeArguments.swift; sourceTree = "<group>"; };
 		094526B51BEA520B0034E72A /* Definition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Definition.swift; sourceTree = "<group>"; };
 		094526B71BEA536A0034E72A /* RuntimeArgumentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuntimeArgumentsTests.swift; sourceTree = "<group>"; };
+		09969C541BEB7C0A00F93C70 /* Dip.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Dip.podspec; path = ../Dip.podspec; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,7 +107,7 @@
 		094526AF1BEA1E0B0034E72A /* Podspec Metadata */ = {
 			isa = PBXGroup;
 			children = (
-				094526AE1BEA1D5E0034E72A /* Dip.podspec */,
+				09969C541BEB7C0A00F93C70 /* Dip.podspec */,
 				094526B01BEA1E1C0034E72A /* README.md */,
 				094526B11BEA1E1C0034E72A /* CHANGELOG.md */,
 				094526B21BEA1E1C0034E72A /* LICENSE */,
@@ -205,6 +206,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				09969C551BEB7C0A00F93C70 /* Dip.podspec in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Dip/Dip.xcodeproj/project.pbxproj
+++ b/Dip/Dip.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		0945269C1BEA1CFF0034E72A /* Dip.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 094526911BEA1CFF0034E72A /* Dip.framework */; };
 		094526A11BEA1CFF0034E72A /* DipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094526A01BEA1CFF0034E72A /* DipTests.swift */; };
 		094526AC1BEA1D200034E72A /* Dip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094526AB1BEA1D200034E72A /* Dip.swift */; };
+		094526B41BEA51540034E72A /* RuntimeArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094526B31BEA51540034E72A /* RuntimeArguments.swift */; };
+		094526B61BEA520B0034E72A /* Definition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094526B51BEA520B0034E72A /* Definition.swift */; };
+		094526B81BEA536A0034E72A /* RuntimeArgumentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094526B71BEA536A0034E72A /* RuntimeArgumentsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,6 +38,9 @@
 		094526B01BEA1E1C0034E72A /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		094526B11BEA1E1C0034E72A /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../CHANGELOG.md; sourceTree = "<group>"; };
 		094526B21BEA1E1C0034E72A /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		094526B31BEA51540034E72A /* RuntimeArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuntimeArguments.swift; sourceTree = "<group>"; };
+		094526B51BEA520B0034E72A /* Definition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Definition.swift; sourceTree = "<group>"; };
+		094526B71BEA536A0034E72A /* RuntimeArgumentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuntimeArgumentsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +86,8 @@
 			children = (
 				094526941BEA1CFF0034E72A /* Dip.h */,
 				094526AB1BEA1D200034E72A /* Dip.swift */,
+				094526B31BEA51540034E72A /* RuntimeArguments.swift */,
+				094526B51BEA520B0034E72A /* Definition.swift */,
 				094526961BEA1CFF0034E72A /* Info.plist */,
 			);
 			path = Dip;
@@ -89,6 +97,7 @@
 			isa = PBXGroup;
 			children = (
 				094526A01BEA1CFF0034E72A /* DipTests.swift */,
+				094526B71BEA536A0034E72A /* RuntimeArgumentsTests.swift */,
 				094526A21BEA1CFF0034E72A /* Info.plist */,
 			);
 			path = DipTests;
@@ -214,6 +223,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				094526AC1BEA1D200034E72A /* Dip.swift in Sources */,
+				094526B61BEA520B0034E72A /* Definition.swift in Sources */,
+				094526B41BEA51540034E72A /* RuntimeArguments.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -222,6 +233,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				094526A11BEA1CFF0034E72A /* DipTests.swift in Sources */,
+				094526B81BEA536A0034E72A /* RuntimeArgumentsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Dip/Dip.xcodeproj/project.pbxproj
+++ b/Dip/Dip.xcodeproj/project.pbxproj
@@ -38,8 +38,8 @@
 		094526B01BEA1E1C0034E72A /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		094526B11BEA1E1C0034E72A /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../CHANGELOG.md; sourceTree = "<group>"; };
 		094526B21BEA1E1C0034E72A /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
-		094526B31BEA51540034E72A /* RuntimeArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuntimeArguments.swift; sourceTree = "<group>"; };
-		094526B51BEA520B0034E72A /* Definition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Definition.swift; sourceTree = "<group>"; };
+		094526B31BEA51540034E72A /* RuntimeArguments.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = RuntimeArguments.swift; sourceTree = "<group>"; tabWidth = 2; };
+		094526B51BEA520B0034E72A /* Definition.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = Definition.swift; sourceTree = "<group>"; tabWidth = 2; };
 		094526B71BEA536A0034E72A /* RuntimeArgumentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuntimeArgumentsTests.swift; sourceTree = "<group>"; };
 		09969C541BEB7C0A00F93C70 /* Dip.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Dip.podspec; path = ../Dip.podspec; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -71,7 +71,9 @@
 				0945269F1BEA1CFF0034E72A /* DipTests */,
 				094526921BEA1CFF0034E72A /* Products */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
 		};
 		094526921BEA1CFF0034E72A /* Products */ = {
 			isa = PBXGroup;

--- a/Dip/Dip/Definition.swift
+++ b/Dip/Dip/Definition.swift
@@ -11,22 +11,22 @@ import Foundation
 ///Internal representation of a key used to associate definitons and factories by tag, type and factory.
 struct DefinitionKey : Hashable, Equatable, CustomDebugStringConvertible {
     var protocolType: Any.Type
-    var factory: Any.Type
+    var factoryType: Any.Type
     var associatedTag: DependencyContainer.Tag?
     
     var hashValue: Int {
-        return "\(protocolType)-\(factory)-\(associatedTag)".hashValue
+        return "\(protocolType)-\(factoryType)-\(associatedTag)".hashValue
     }
     
     var debugDescription: String {
-        return "type: \(protocolType), factory: \(factory), tag: \(associatedTag)"
+        return "type: \(protocolType), factory: \(factoryType), tag: \(associatedTag)"
     }
 }
 
 func ==(lhs: DefinitionKey, rhs: DefinitionKey) -> Bool {
     return
         lhs.protocolType == rhs.protocolType &&
-            lhs.factory == rhs.factory &&
+            lhs.factoryType == rhs.factoryType &&
             lhs.associatedTag == rhs.associatedTag
 }
 

--- a/Dip/Dip/Definition.swift
+++ b/Dip/Dip/Definition.swift
@@ -1,0 +1,66 @@
+//
+//  Definition.swift
+//  Dip
+//
+//  Created by Ilya Puchka on 04.11.15.
+//  Copyright © 2015 AliSoftware. All rights reserved.
+//
+
+import Foundation
+
+///Internal representation of a key used to associate definitons and factories by tag, type and factory.
+struct DefinitionKey : Hashable, Equatable, CustomDebugStringConvertible {
+    var protocolType: Any.Type
+    var factory: Any.Type
+    var associatedTag: DependencyContainer.Tag?
+    
+    var hashValue: Int {
+        return "\(protocolType)-\(factory)-\(associatedTag)".hashValue
+    }
+    
+    var debugDescription: String {
+        return "type: \(protocolType), factory: \(factory), tag: \(associatedTag)"
+    }
+}
+
+func ==(lhs: DefinitionKey, rhs: DefinitionKey) -> Bool {
+    return
+        lhs.protocolType == rhs.protocolType &&
+            lhs.factory == rhs.factory &&
+            lhs.associatedTag == rhs.associatedTag
+}
+
+///Describes the lifecycle of instances created by container.
+public enum ComponentScope {
+    /// Indicates that new instance of the component will be always created.
+    case Prototype
+    /// Indicates that resolved component should be retained by container and always reused.
+    case Singleton
+}
+
+///Definition of type T describes how instances of this type should be created when they are resolved by container.
+public final class DefinitionOf<T>: Definition {
+    let factory: Any
+    let scope: ComponentScope
+    
+    init(factory: Any, scope: ComponentScope = .Prototype) {
+        self.factory = factory
+        self.scope = scope
+    }
+    
+    var resolvedInstance: T? {
+        get {
+            guard scope == .Singleton else { return nil }
+            return _resolvedInstance
+        }
+        set {
+            guard scope == .Singleton else { return }
+            _resolvedInstance = newValue
+        }
+    }
+    
+    private var _resolvedInstance: T?
+}
+
+///Dummy protocol to store definitions for different types in collection
+protocol Definition {}

--- a/Dip/Dip/Definition.swift
+++ b/Dip/Dip/Definition.swift
@@ -32,7 +32,7 @@ func ==(lhs: DefinitionKey, rhs: DefinitionKey) -> Bool {
 
 ///Describes the lifecycle of instances created by container.
 public enum ComponentScope {
-    /// Indicates that new instance of the component will be always created.
+    /// Indicates that a new instance of the component will be created each time it's resolved.
     case Prototype
     /// Indicates that resolved component should be retained by container and always reused.
     case Singleton

--- a/Dip/Dip/Definition.swift
+++ b/Dip/Dip/Definition.swift
@@ -10,56 +10,56 @@ import Foundation
 
 ///Internal representation of a key used to associate definitons and factories by tag, type and factory.
 struct DefinitionKey : Hashable, Equatable, CustomDebugStringConvertible {
-    var protocolType: Any.Type
-    var factoryType: Any.Type
-    var associatedTag: DependencyContainer.Tag?
-    
-    var hashValue: Int {
-        return "\(protocolType)-\(factoryType)-\(associatedTag)".hashValue
-    }
-    
-    var debugDescription: String {
-        return "type: \(protocolType), factory: \(factoryType), tag: \(associatedTag)"
-    }
+  var protocolType: Any.Type
+  var factoryType: Any.Type
+  var associatedTag: DependencyContainer.Tag?
+  
+  var hashValue: Int {
+    return "\(protocolType)-\(factoryType)-\(associatedTag)".hashValue
+  }
+  
+  var debugDescription: String {
+    return "type: \(protocolType), factory: \(factoryType), tag: \(associatedTag)"
+  }
 }
 
 func ==(lhs: DefinitionKey, rhs: DefinitionKey) -> Bool {
-    return
-        lhs.protocolType == rhs.protocolType &&
-            lhs.factoryType == rhs.factoryType &&
-            lhs.associatedTag == rhs.associatedTag
+  return
+    lhs.protocolType == rhs.protocolType &&
+      lhs.factoryType == rhs.factoryType &&
+      lhs.associatedTag == rhs.associatedTag
 }
 
 ///Describes the lifecycle of instances created by container.
 public enum ComponentScope {
-    /// Indicates that a new instance of the component will be created each time it's resolved.
-    case Prototype
-    /// Indicates that resolved component should be retained by container and always reused.
-    case Singleton
+  /// Indicates that a new instance of the component will be created each time it's resolved.
+  case Prototype
+  /// Indicates that resolved component should be retained by container and always reused.
+  case Singleton
 }
 
 ///Definition of type T describes how instances of this type should be created when they are resolved by container.
 public final class DefinitionOf<T>: Definition {
-    let factory: Any
-    let scope: ComponentScope
-    
-    init(factory: Any, scope: ComponentScope = .Prototype) {
-        self.factory = factory
-        self.scope = scope
+  let factory: Any
+  let scope: ComponentScope
+  
+  init(factory: Any, scope: ComponentScope = .Prototype) {
+    self.factory = factory
+    self.scope = scope
+  }
+  
+  var resolvedInstance: T? {
+    get {
+      guard scope == .Singleton else { return nil }
+      return _resolvedInstance
     }
-    
-    var resolvedInstance: T? {
-        get {
-            guard scope == .Singleton else { return nil }
-            return _resolvedInstance
-        }
-        set {
-            guard scope == .Singleton else { return }
-            _resolvedInstance = newValue
-        }
+    set {
+      guard scope == .Singleton else { return }
+      _resolvedInstance = newValue
     }
-    
-    private var _resolvedInstance: T?
+  }
+  
+  private var _resolvedInstance: T?
 }
 
 ///Dummy protocol to store definitions for different types in collection

--- a/Dip/Dip/Dip.swift
+++ b/Dip/Dip/Dip.swift
@@ -35,8 +35,8 @@ public class DependencyContainer {
      - parameter configBlock: A configuration block in which you typically put all you `register` calls.
      
      - note: The `configBlock` is simply called at the end of the `init` to let you configure everything. 
-     It is only present for convenience to have a cleaner syntax when declaring and initializing 
-     your `DependencyContainer` instances.
+             It is only present for convenience to have a cleaner syntax when declaring and initializing
+             your `DependencyContainer` instances.
      
      - returns: A new DependencyContainer.
      */
@@ -88,7 +88,9 @@ public class DependencyContainer {
      - parameter factory: generic factory that should be used to create concrete instance of type
      - parameter scope: scope of the component. Default value is `Prototype`
 
-     -note: You should not call this method directly, instead call any of other `register` methods. You _should_ use this method only to register dependency with more runtime arguments than _Dip_ supports (currently it's up to six) like in this example:
+     - note: You should not call this method directly, instead call any of other `register` methods.
+             You _should_ use this method only to register dependency with more runtime arguments
+             than _Dip_ supports (currently it's up to six) like in this example:
      
      ```swift
      public func register<T, Arg1, Arg2, Arg3, ...>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, ...) -> T) -> DefinitionOf<T> {

--- a/Dip/Dip/Dip.swift
+++ b/Dip/Dip/Dip.swift
@@ -65,8 +65,8 @@ public class DependencyContainer {
      
      - note: You must cast the factory return type to the protocol you want to register it with (e.g `MyClass() as MyAPI`)
      */
-    public func register<T>(tag: Tag? = nil, factory: ()->T) -> DefinitionOf<T> {
-        return register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+    public func register<T>(tag tag: Tag? = nil, factory: ()->T) -> DefinitionOf<T> {
+        return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
     }
     
     /**
@@ -77,8 +77,8 @@ public class DependencyContainer {
      
      - note: You must cast the instance to the protocol you want to register it with (e.g `MyClass() as MyAPI`)
      */
-    public func register<T>(tag: Tag? = nil, @autoclosure(escaping) instance factory: ()->T) -> DefinitionOf<T> {
-        return register(tag, factory: { factory() }, scope: .Singleton)
+    public func register<T>(tag tag: Tag? = nil, @autoclosure(escaping) instance factory: ()->T) -> DefinitionOf<T> {
+        return register(tag: tag, factory: { factory() }, scope: .Singleton)
     }
     
     /**
@@ -97,7 +97,7 @@ public class DependencyContainer {
      }
      ```
      */
-    public func register<T, F>(tag: Tag? = nil, factory: F, scope: ComponentScope) -> DefinitionOf<T> {
+    public func register<T, F>(tag tag: Tag? = nil, factory: F, scope: ComponentScope) -> DefinitionOf<T> {
         let key = DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: tag)
         let definition = DefinitionOf<T>(factory: factory, scope: scope)
         lockAndDo {
@@ -116,7 +116,7 @@ public class DependencyContainer {
     - parameter tag: The arbitrary tag to look for when resolving this protocol.
     */
     public func resolve<T>(tag tag: Tag? = nil) -> T {
-        return resolve(tag) { (factory: ()->T) in factory() }
+        return resolve(tag: tag) { (factory: ()->T) in factory() }
     }
     
     /**
@@ -136,7 +136,7 @@ public class DependencyContainer {
      ```
      
     */
-    public func resolve<T, F>(tag: Tag? = nil, builder: F->T) -> T {
+    public func resolve<T, F>(tag tag: Tag? = nil, builder: F->T) -> T {
         let key = DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: tag)
         let nilTagKey = tag.map { _ in DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: nil) }
         

--- a/Dip/Dip/Dip.swift
+++ b/Dip/Dip/Dip.swift
@@ -127,7 +127,9 @@ public class DependencyContainer {
      - parameter tag: The arbitrary tag to look for when resolving this protocol.
      - parameter builder: Generic closure that accepts generic factory and returns inctance produced by that factory
      
-     - note: You should not call this method directly, instead call any of other `resolve` methods. You _should_ use this method only to resolve dependency with more runtime arguments than _Dip_ supports (currently it's up to six) like in this example:
+     - note: You should not call this method directly, instead call any of other `resolve` methods. (see `RuntimeArguments.swift`).
+             You _should_ use this method only to resolve dependency with more runtime arguments than _Dip_ supports
+             (currently it's up to six) like in this example:
      
      ```swift
      public func resolve<T, Arg1, Arg2, Arg3, ...>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, ...) -> T {
@@ -135,7 +137,7 @@ public class DependencyContainer {
      }
      ```
      
-     Though before you do that you should probably review your design and try to reduce number of depnedencies.
+     Though before you do that you should probably review your design and try to reduce the number of dependencies.
      
     */
     public func resolve<T, F>(tag tag: Tag? = nil, builder: F->T) -> T {

--- a/Dip/Dip/Dip.swift
+++ b/Dip/Dip/Dip.swift
@@ -98,7 +98,7 @@ public class DependencyContainer {
      ```
      */
     public func register<T, F>(tag: Tag? = nil, factory: F, scope: ComponentScope) -> DefinitionOf<T> {
-        let key = DefinitionKey(protocolType: T.self, factory: F.self, associatedTag: tag)
+        let key = DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: tag)
         let definition = DefinitionOf<T>(factory: factory, scope: scope)
         lockAndDo {
             dependencies[key] = definition
@@ -137,8 +137,8 @@ public class DependencyContainer {
      
     */
     public func resolve<T, F>(tag: Tag? = nil, builder: F->T) -> T {
-        let key = DefinitionKey(protocolType: T.self, factory: F.self, associatedTag: tag)
-        let nilTagKey = tag.map { _ in DefinitionKey(protocolType: T.self, factory: F.self, associatedTag: nil) }
+        let key = DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: tag)
+        let nilTagKey = tag.map { _ in DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: nil) }
         
         var resolved: T!
         lockAndDo { [unowned self] in

--- a/Dip/Dip/Dip.swift
+++ b/Dip/Dip/Dip.swift
@@ -58,18 +58,6 @@ public class DependencyContainer {
     // MARK: Register dependencies
     
     /**
-    Register a `Tag?->T` factory (which takes the tag as parameter) with a given tag
-    
-    - parameter tag:     The arbitrary tag to associate this factory with when registering with that protocol. `nil` to associate with any tag.
-    - parameter factory: The factory to register, typed/casted as the protocol you want to register it as
-    
-    - note: You must cast the factory return type to the protocol you want to register it with (e.g `MyClass() as MyAPI`)
-    */
-    public func register<T>(tag: Tag? = nil, factory: (Tag?)->T) {
-        _register(tag, factory: factory) as DefinitionOf<T>
-    }
-    
-    /**
      Register a Void->T factory (which don't care about the tag used)
      
      - parameter tag:     The arbitrary tag to associate this factory with when registering with that protocol. `nil` to associate with any tag.

--- a/Dip/Dip/Dip.swift
+++ b/Dip/Dip/Dip.swift
@@ -88,14 +88,16 @@ public class DependencyContainer {
      - parameter factory: generic factory that should be used to create concrete instance of type
      - parameter scope: scope of the component. Default value is `Prototype`
 
-     -note: You should not call this method directly, instead call any of other `register` methods. You _should_ use this method only to register dependency with more runtime arguments than _Dip_ supports (currently it's up to six). Though before you do that you should probably review your design and try to reduce number of depnedencies.
+     -note: You should not call this method directly, instead call any of other `register` methods. You _should_ use this method only to register dependency with more runtime arguments than _Dip_ supports (currently it's up to six) like in this example:
      
-     **Example**
      ```swift
-     public func register<T, Arg1, Arg2, Arg3, ...>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, ...) -> T) {
-         register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+     public func register<T, Arg1, Arg2, Arg3, ...>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, ...) -> T) -> DefinitionOf<T> {
+         return register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
      }
      ```
+     
+     Though before you do that you should probably review your design and try to reduce number of depnedencies.
+     
      */
     public func register<T, F>(tag tag: Tag? = nil, factory: F, scope: ComponentScope) -> DefinitionOf<T> {
         let key = DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: tag)
@@ -125,15 +127,15 @@ public class DependencyContainer {
      - parameter tag: The arbitrary tag to look for when resolving this protocol.
      - parameter builder: Generic closure that accepts generic factory and returns inctance produced by that factory
      
-     - note: You should not call this method directly, instead call any of other `resolve` methods. You _should_ use this method only to register dependency with more runtime arguments than _Dip_ supports (currently it's up to six). Though before you do that you should probably review your design and try to reduce number of depnedencies.
-     
-     **Example**
+     - note: You should not call this method directly, instead call any of other `resolve` methods. You _should_ use this method only to resolve dependency with more runtime arguments than _Dip_ supports (currently it's up to six) like in this example:
      
      ```swift
      public func resolve<T, Arg1, Arg2, Arg3, ...>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, ...) -> T {
          return resolve(tag) { (factory: (Arg1, Arg2, Arg3, ...) -> T) in factory(arg1, arg2, arg3, ...) }
      }
      ```
+     
+     Though before you do that you should probably review your design and try to reduce number of depnedencies.
      
     */
     public func resolve<T, F>(tag tag: Tag? = nil, builder: F->T) -> T {

--- a/Dip/Dip/Dip.swift
+++ b/Dip/Dip/Dip.swift
@@ -16,184 +16,278 @@ import Foundation
  */
 public class DependencyContainer {
   
-  /**
-   Use a tag in case you need to register multiple instances or factories
-   with the same protocol, to differentiate them. Tags can be either String
-   or Int, to your convenience.
-   */
-  public enum Tag: Equatable {
-    case String(StringLiteralType)
-    case Int(IntegerLiteralType)
-  }
+    /**
+     Use a tag in case you need to register multiple instances or factories
+     with the same protocol, to differentiate them. Tags can be either String
+     or Int, to your convenience.
+     */
+    public enum Tag: Equatable {
+        case String(StringLiteralType)
+        case Int(IntegerLiteralType)
+    }
 
-  /**
-   *  Internal representation of a key to associate protocols & tags to an instance factory
-   */
-  private struct LookupKey : Hashable, Equatable, CustomDebugStringConvertible {
-    var protocolType: Any.Type
-    var associatedTag: Tag?
+    private var dependencies = [DefinitionKey : Definition]()
+    private var lock: OSSpinLock = OS_SPINLOCK_INIT
     
-    var hashValue: Int {
-      return "\(protocolType)-\(associatedTag)".hashValue
+    /**
+     Designated initializer for a DependencyContainer
+     
+     - parameter configBlock: A configuration block in which you typically put all you `register` calls.
+     
+     - note: The `configBlock` is simply called at the end of the `init` to let you configure everything.
+     It is only present for convenience to have a cleaner syntax when declaring and initializing
+     your `DependencyContainer` instances.
+     
+     - returns: A new DependencyContainer.
+     */
+    public init(@noescape configBlock: (DependencyContainer->()) = { _ in }) {
+        configBlock(self)
     }
     
-    var debugDescription: String {
-      return "type: \(protocolType), tag: \(associatedTag)"
-    }
-  }
-  
-  private typealias InstanceType = Any
-  private typealias InstanceFactory = Tag?->InstanceType
-  private typealias Key = LookupKey
-  
-  private var dependencies = [Key : InstanceFactory]()
-  private var lock: OSSpinLock = OS_SPINLOCK_INIT
-  
-  // MARK: - Init & Reset
-
-  /**
-   Designated initializer for a DependencyContainer
-   
-   - parameter configBlock: A configuration block in which you typically put all you `register` calls.
-   
-   - note: The `configBlock` is simply called at the end of the `init` to let you configure everything.
-   It is only present for convenience to have a cleaner syntax when declaring and initializing
-   your `DependencyContainer` instances.
-   
-   - returns: A new DependencyContainer
-   */
-  public init(@noescape configBlock: (DependencyContainer->Void) = { _ in }) {
-    configBlock(self)
-  }
-  
-  /**
-  Clear all the previously registered dependencies on this container
-  */
-  public func reset() {
-    lockAndDo {
-      dependencies.removeAll()
-    }
-  }
-  
-  // MARK: Register dependencies
-  
-  /**
-  Register a `TagType?->T` factory (which takes the tag as parameter) with a given tag
-  
-  - parameter tag:     The arbitrary tag to associate this factory with when registering with that protocol. `nil` to associate with any tag.
-  - parameter factory: The factory to register, typed/casted as the protocol you want to register it as
-  
-  - note: You must cast the factory return type to the protocol you want to register it with (e.g `MyClass() as MyAPI`)
-  */
-  public func register<T>(tag: Tag? = nil, factory: Tag?->T) {
-    let key = Key(protocolType: T.self, associatedTag: tag)
-    lockAndDo {
-      dependencies[key] = { factory($0) }
-    }
-  }
-  
-  /**
-   Register a Void->T factory (which don't care about the tag used)
-   
-   - parameter tag:     The arbitrary tag to associate this factory with when registering with that protocol. `nil` to associate with any tag.
-   - parameter factory: The factory to register, typed/casted as the protocol you want to register it as
-   
-   - note: You must cast the factory return type to the protocol you want to register it with (e.g `MyClass() as MyAPI`)
-   */
-  public func register<T>(tag: Tag? = nil, factory: Void->T) {
-    let key = Key(protocolType: T.self, associatedTag: tag)
-    lockAndDo {
-      dependencies[key] = { _ in factory() }
-    }
-  }
-  
-  /**
-   Register a Singleton instance
-   
-   
-   - parameter tag:      The arbitrary tag to associate this instance with when registering with that protocol. `nil` to associate with any tag.
-   - parameter instance: The instance to register, typed/casted as the protocol you want to register it as
-   
-   - note: You must cast the instance to the protocol you want to register it with (e.g `MyClass() as MyAPI`)
-   */
-  public func register<T>(tag: Tag? = nil, @autoclosure(escaping) instance factory: Void->T) {
-    let key = Key(protocolType: T.self, associatedTag: tag)
-    lockAndDo {
-      dependencies[key] = { _ in
-        let instance = factory()
-        self.dependencies[key] = { _ in return instance }
-        return instance
-      }
-    }
-  }
-  
-  // MARK: Resolve dependencies
-  
-  /**
-  Resolve a dependency
-  
-  - parameter tag: The arbitrary tag to look for when resolving this protocol.
-  If no instance/factory was registered with this `tag` for this `protocol`,
-  it will resolve to the instance/factory associated with `nil` (no tag).
-  */
-  public func resolve<T>(tag: Tag? = nil) -> T! {
-    let key = Key(protocolType: T.self, associatedTag: tag)
-    let nilKey = Key(protocolType: T.self, associatedTag: nil)
-    var resolved: T!
-    lockAndDo { [unowned self] in
-      guard let factory = self.dependencies[key] ?? self.dependencies[nilKey] else {
-        fatalError("No instance factory registered with \(key)")
-      }
-      resolved = factory(tag) as! T
-    }
-    return resolved
-  }
+    // MARK: - Reset all dependencies
     
-  // MARK: - Private Helper
-  
-  private func lockAndDo(@noescape block: Void->Void) {
-    OSSpinLockLock(&lock)
-    defer { OSSpinLockUnlock(&lock) }
-    block()
-  }
-}
-
-// MARK: - Class Extensions
-
-private func ==(lhs: DependencyContainer.LookupKey, rhs: DependencyContainer.LookupKey) -> Bool {
-  return lhs.protocolType == rhs.protocolType && lhs.associatedTag == rhs.associatedTag
+    /**
+    Clear all the previously registered dependencies on this container.
+    */
+    public func reset() {
+        lockAndDo {
+            dependencies.removeAll()
+        }
+    }
+    
+    // MARK: Register dependencies
+    
+    /**
+    Register a `Tag?->T` factory (which takes the tag as parameter) with a given tag
+    
+    - parameter tag:     The arbitrary tag to associate this factory with when registering with that protocol. `nil` to associate with any tag.
+    - parameter factory: The factory to register, typed/casted as the protocol you want to register it as
+    
+    - note: You must cast the factory return type to the protocol you want to register it with (e.g `MyClass() as MyAPI`)
+    */
+    public func register<T>(tag: Tag? = nil, factory: (Tag?)->T) {
+        _register(tag, factory: factory) as DefinitionOf<T>
+    }
+    
+    /**
+     Register a Void->T factory (which don't care about the tag used)
+     
+     - parameter tag:     The arbitrary tag to associate this factory with when registering with that protocol. `nil` to associate with any tag.
+     - parameter factory: The factory to register, typed/casted as the protocol you want to register it as
+     
+     - note: You must cast the factory return type to the protocol you want to register it with (e.g `MyClass() as MyAPI`)
+     */
+    public func register<T>(tag: Tag? = nil, factory: ()->T) {
+        _register(tag, factory: factory) as DefinitionOf<T>
+    }
+    
+    /**
+     Register a Singleton instance
+     
+     - parameter tag:      The arbitrary tag to associate this instance with when registering with that protocol. `nil` to associate with any tag.
+     - parameter instance: The instance to register, typed/casted as the protocol you want to register it as
+     
+     - note: You must cast the instance to the protocol you want to register it with (e.g `MyClass() as MyAPI`)
+     */
+    public func register<T>(tag: Tag? = nil, @autoclosure(escaping) instance factory: ()->T) {
+        _register(tag, factory: { factory() }, scope: .Singleton) as DefinitionOf<T>
+    }
+    
+    private func _register<T, F>(tag: Tag? = nil, factory: F, scope: ComponentScope = .Prototype) -> DefinitionOf<T> {
+        let key = DefinitionKey(protocolType: T.self, factory: F.self, associatedTag: tag)
+        let definition = DefinitionOf<T>(factory: factory, scope: scope)
+        lockAndDo {
+            dependencies[key] = definition
+        }
+        return definition
+    }
+    
+    // MARK: Resolve dependencies
+    
+    /**
+    Resolve a dependency
+    
+    - parameter tag: The arbitrary tag to look for when resolving this protocol.
+    If no instance/factory was registered with this `tag` for this `protocol`,
+    it will resolve to the instance/factory associated with `nil` (no tag).
+    */
+    public func resolve<T>(tag: Tag? = nil) -> T {
+        return _resolve(tag) { (factory: ()->T) in factory() }
+    }
+    
+    private func _resolve<T, F>(tag: Tag? = nil, builder: F->T) -> T {
+        let key = DefinitionKey(protocolType: T.self, factory: F.self, associatedTag: tag)
+        let nilTagKey = DefinitionKey(protocolType: T.self, factory: F.self, associatedTag: nil)
+        
+        var resolved: T!
+        lockAndDo { [unowned self] in
+            resolved = self._resolve(key, nilTagKey: nilTagKey, builder: builder)
+        }
+        return resolved
+    }
+    
+    private func _resolve<T, F>(key: DefinitionKey, nilTagKey: DefinitionKey, builder: F->T) -> T {
+        guard let definition = (self.dependencies[key] ?? self.dependencies[nilTagKey]) as? DefinitionOf<T> else {
+            fatalError("No instance factory registered with \(key) or \(nilTagKey)")
+        }
+        
+        if let resolvedInstance = definition.resolvedInstance {
+            return resolvedInstance
+        }
+        else {
+            let resolved = builder(definition.factory as! F)
+            definition.resolvedInstance = resolved
+            return resolved
+        }
+    }
+    
+    // MARK: - Private
+    
+    private func lockAndDo(@noescape block: Void->Void) {
+        OSSpinLockLock(&lock)
+        defer { OSSpinLockUnlock(&lock) }
+        block()
+    }
 }
 
 extension DependencyContainer.Tag: IntegerLiteralConvertible {
-  public init(integerLiteral value: IntegerLiteralType) {
-    self = .Int(value)
-  }
+    public init(integerLiteral value: IntegerLiteralType) {
+        self = .Int(value)
+    }
 }
 
 extension DependencyContainer.Tag: StringLiteralConvertible {
-  public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
-  public typealias UnicodeScalarLiteralType = StringLiteralType
-  
-  public init(stringLiteral value: StringLiteralType) {
-    self = .String(value)
-  }
-  
-  public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
-    self.init(stringLiteral: value)
-  }
-  
-  public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
-    self.init(stringLiteral: value)
-  }
+    public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
+    public typealias UnicodeScalarLiteralType = StringLiteralType
+    
+    public init(stringLiteral value: StringLiteralType) {
+        self = .String(value)
+    }
+    
+    public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
+        self.init(stringLiteral: value)
+    }
+    
+    public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
+        self.init(stringLiteral: value)
+    }
 }
 
 public func ==(lhs: DependencyContainer.Tag, rhs: DependencyContainer.Tag) -> Bool {
-  switch (lhs, rhs) {
-  case let (.String(lhsString), .String(rhsString)):
-    return lhsString == rhsString
-  case let (.Int(lhsInt), .Int(rhsInt)):
-    return lhsInt == rhsInt
-  default:
-    return false
-  }
+    switch (lhs, rhs) {
+    case let (.String(lhsString), .String(rhsString)):
+        return lhsString == rhsString
+    case let (.Int(lhsInt), .Int(rhsInt)):
+        return lhsInt == rhsInt
+    default:
+        return false
+    }
+}
+
+/**
+ *  Internal representation of a key to associate protocols & tags to an instance factory
+ */
+private struct DefinitionKey : Hashable, Equatable, CustomDebugStringConvertible {
+    var protocolType: Any.Type
+    var factory: Any.Type
+    var associatedTag: DependencyContainer.Tag?
+    
+    var hashValue: Int {
+        return "\(protocolType)-\(factory)-\(associatedTag)".hashValue
+    }
+    
+    var debugDescription: String {
+        return "type: \(protocolType), factory: \(factory), tag: \(associatedTag)"
+    }
+}
+
+private func ==(lhs: DefinitionKey, rhs: DefinitionKey) -> Bool {
+    return
+        lhs.protocolType == rhs.protocolType &&
+            lhs.factory == rhs.factory &&
+            lhs.associatedTag == rhs.associatedTag
+}
+
+///Describes the lifecycle of instances created by container.
+public enum ComponentScope {
+    /// (default) Indicates that new instance of the component will be always created.
+    case Prototype
+    /// Indicates that resolved component should be retained by container and always reused.
+    case Singleton
+}
+
+public final class DefinitionOf<T>: Definition {
+    private let factory: Any
+    private let scope: ComponentScope
+    
+    init(factory: Any, scope: ComponentScope = .Prototype) {
+        self.factory = factory
+        self.scope = scope
+    }
+    
+    private var resolvedInstance: T? {
+        get {
+            guard scope == .Singleton else { return nil }
+            return _resolvedInstance
+        }
+        set {
+            guard scope == .Singleton else { return }
+            _resolvedInstance = newValue
+        }
+    }
+    
+    private var _resolvedInstance: T?
+}
+
+private protocol Definition {}
+
+// MARK: - Register dependencies with runtime arguments
+extension DependencyContainer {
+    public func register<T, Arg1>(tag: Tag? = nil, factory: (Arg1) -> T) {
+        _register(tag, factory: factory) as DefinitionOf<T>
+    }
+    
+    public func resolve<T, Arg1>(tag: Tag? = nil, _ arg1: Arg1) -> T {
+        return _resolve(tag) { (factory: (Arg1) -> T) in factory(arg1) }
+    }
+    
+    public func register<T, Arg1, Arg2>(tag: Tag? = nil, factory: (Arg1, Arg2) -> T) {
+        _register(tag, factory: factory) as DefinitionOf<T>
+    }
+    
+    public func resolve<T, Arg1, Arg2>(tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2) -> T {
+        return _resolve(tag) { (factory: (Arg1, Arg2) -> T) in factory(arg1, arg2) }
+    }
+    
+    public func register<T, Arg1, Arg2, Arg3>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3) -> T) {
+        _register(tag, factory: factory) as DefinitionOf<T>
+    }
+    
+    public func resolve<T, Arg1, Arg2, Arg3>(tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> T {
+        return _resolve(tag) { (factory: (Arg1, Arg2, Arg3) -> T) in factory(arg1, arg2, arg3) }
+    }
+    
+    public func register<T, Arg1, Arg2, Arg3, Arg4>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4) -> T) {
+        _register(tag, factory: factory) as DefinitionOf<T>
+    }
+    
+    public func resolve<T, Arg1, Arg2, Arg3, Arg4>(tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> T {
+        return _resolve(tag) { (factory: (Arg1, Arg2, Arg3, Arg4) -> T) in factory(arg1, arg2, arg3, arg4) }
+    }
+    
+    public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) {
+        _register(tag, factory: factory) as DefinitionOf<T>
+    }
+    
+    public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, arg5: Arg5) -> T {
+        return _resolve(tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) in factory(arg1, arg2, arg3, arg4, arg5) }
+    }
+    
+    public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T) {
+        _register(tag, factory: factory) as DefinitionOf<T>
+    }
+    
+    public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> T {
+        return _resolve(tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T) in factory(arg1, arg2, arg3, arg4, arg5, arg6) }
+    }
 }

--- a/Dip/Dip/RuntimeArguments.swift
+++ b/Dip/Dip/RuntimeArguments.swift
@@ -11,92 +11,92 @@ import Foundation
 // MARK: - Register/resolve dependencies with runtime arguments
 
 extension DependencyContainer {
-
-    // MARK: 1 Runtime Argument
-
-    /**
-     Registers factory that accepts one runtime argument. You can use up to six runtime arguments.
-
-     - parameter tag: The arbitrary tag to associate this factory with when registering with that protocol.
-                      Pass `nil` to associate with any tag. Default value is `nil`.
-     - parameter factory: The factory to register, with return type of protocol you want to register it for
-
-     - note: You can have several factories with different number or types of arguments registered to for same type.
-             When you resolve it container will match the type and tag as well as __number__, __types__ and __order__
-             of runtime arguments that you pass to `resolve` method.
-
-     - seealso: `register(tag:factory:scope:)`
-     */
-    public func register<T, Arg1>(tag tag: Tag? = nil, factory: (Arg1) -> T) -> DefinitionOf<T> {
-        return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
-    }
-    
-    /**
-     Resolve a dependency with runtime argument. Factories will be matched by tag and the type to resolve as well
-       as __number__, __types__ and __order__ of runtime arguments that you pass to this method.
-     
-     - parameter tag: The arbitrary tag to look for when resolving this protocol.
-     - parameter arg1: First argument to be passed to factory
-     
-     - seealso: `resolve(tag:)`
-    */
-    public func resolve<T, Arg1>(tag tag: Tag? = nil, _ arg1: Arg1) -> T {
-        return resolve(tag: tag) { (factory: (Arg1) -> T) in factory(arg1) }
-    }
-
-    // MARK: 2 Runtime Arguments
-
-    /// - seealso: `register(:factory:scope:)`
-    public func register<T, Arg1, Arg2>(tag tag: Tag? = nil, factory: (Arg1, Arg2) -> T) -> DefinitionOf<T> {
-        return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
-    }
-    
-    /// - seealso: `resolve(tag:_:)`
-    public func resolve<T, Arg1, Arg2>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2) -> T {
-        return resolve(tag: tag) { (factory: (Arg1, Arg2) -> T) in factory(arg1, arg2) }
-    }
   
-    // MARK: 3 Runtime Arguments
-
-    public func register<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3) -> T) -> DefinitionOf<T> {
-        return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
-    }
-    
-    /// - seealso: `resolve(tag:_:)`
-    public func resolve<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> T {
-        return resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3) -> T) in factory(arg1, arg2, arg3) }
-    }
+  // MARK: 1 Runtime Argument
   
-    // MARK: 4 Runtime Arguments
+  /**
+  Registers factory that accepts one runtime argument. You can use up to six runtime arguments.
   
-    public func register<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4) -> T) -> DefinitionOf<T> {
-        return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
-    }
-    
-    /// - seealso: `resolve(tag:_:)`
-    public func resolve<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> T {
-        return resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4) -> T) in factory(arg1, arg2, arg3, arg4) }
-    }
+  - parameter tag: The arbitrary tag to associate this factory with when registering with that protocol.
+                   Pass `nil` to associate with any tag. Default value is `nil`.
+  - parameter factory: The factory to register, with return type of protocol you want to register it for
   
-    // MARK: 4 Runtime Arguments
+  - note: You can have several factories with different number or types of arguments registered to for same type.
+          When you resolve it container will match the type and tag as well as __number__, __types__ and __order__
+          of runtime arguments that you pass to `resolve` method.
   
-    public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) -> DefinitionOf<T> {
-        return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
-    }
-    
-    /// - seealso: `resolve(tag:_:)`
-    public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> T {
-        return resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) in factory(arg1, arg2, arg3, arg4, arg5) }
-    }
+  - seealso: `register(tag:factory:scope:)`
+  */
+  public func register<T, Arg1>(tag tag: Tag? = nil, factory: (Arg1) -> T) -> DefinitionOf<T> {
+    return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+  }
   
-    // MARK: 5 Runtime Arguments
-
-    public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T) -> DefinitionOf<T> {
-        return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
-    }
-    
-    /// - seealso: `resolve(tag:_:)`
-    public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> T {
-        return resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T) in factory(arg1, arg2, arg3, arg4, arg5, arg6) }
-    }
+  /**
+   Resolve a dependency with runtime argument. Factories will be matched by tag and the type to resolve as well
+   as __number__, __types__ and __order__ of runtime arguments that you pass to this method.
+   
+   - parameter tag: The arbitrary tag to look for when resolving this protocol.
+   - parameter arg1: First argument to be passed to factory
+   
+   - seealso: `resolve(tag:)`
+   */
+  public func resolve<T, Arg1>(tag tag: Tag? = nil, _ arg1: Arg1) -> T {
+    return resolve(tag: tag) { (factory: (Arg1) -> T) in factory(arg1) }
+  }
+  
+  // MARK: 2 Runtime Arguments
+  
+  /// - seealso: `register(:factory:scope:)`
+  public func register<T, Arg1, Arg2>(tag tag: Tag? = nil, factory: (Arg1, Arg2) -> T) -> DefinitionOf<T> {
+    return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+  }
+  
+  /// - seealso: `resolve(tag:_:)`
+  public func resolve<T, Arg1, Arg2>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2) -> T {
+    return resolve(tag: tag) { (factory: (Arg1, Arg2) -> T) in factory(arg1, arg2) }
+  }
+  
+  // MARK: 3 Runtime Arguments
+  
+  public func register<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3) -> T) -> DefinitionOf<T> {
+    return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+  }
+  
+  /// - seealso: `resolve(tag:_:)`
+  public func resolve<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> T {
+    return resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3) -> T) in factory(arg1, arg2, arg3) }
+  }
+  
+  // MARK: 4 Runtime Arguments
+  
+  public func register<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4) -> T) -> DefinitionOf<T> {
+    return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+  }
+  
+  /// - seealso: `resolve(tag:_:)`
+  public func resolve<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> T {
+    return resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4) -> T) in factory(arg1, arg2, arg3, arg4) }
+  }
+  
+  // MARK: 4 Runtime Arguments
+  
+  public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) -> DefinitionOf<T> {
+    return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+  }
+  
+  /// - seealso: `resolve(tag:_:)`
+  public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> T {
+    return resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) in factory(arg1, arg2, arg3, arg4, arg5) }
+  }
+  
+  // MARK: 5 Runtime Arguments
+  
+  public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T) -> DefinitionOf<T> {
+    return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+  }
+  
+  /// - seealso: `resolve(tag:_:)`
+  public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> T {
+    return resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T) in factory(arg1, arg2, arg3, arg4, arg5, arg6) }
+  }
 }

--- a/Dip/Dip/RuntimeArguments.swift
+++ b/Dip/Dip/RuntimeArguments.swift
@@ -22,8 +22,8 @@ extension DependencyContainer {
 
      - seealso: `register(tag:factory:scope:)`
      */
-    public func register<T, Arg1>(tag: Tag? = nil, factory: (Arg1) -> T) -> DefinitionOf<T> {
-        return register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+    public func register<T, Arg1>(tag tag: Tag? = nil, factory: (Arg1) -> T) -> DefinitionOf<T> {
+        return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
     }
     
     /**
@@ -35,52 +35,52 @@ extension DependencyContainer {
      - seealso: `resolve(tag:)`
     */
     public func resolve<T, Arg1>(tag tag: Tag? = nil, _ arg1: Arg1) -> T {
-        return resolve(tag) { (factory: (Arg1) -> T) in factory(arg1) }
+        return resolve(tag: tag) { (factory: (Arg1) -> T) in factory(arg1) }
     }
 
     /// - seealso: `register(:factory:scope:)`
-    public func register<T, Arg1, Arg2>(tag: Tag? = nil, factory: (Arg1, Arg2) -> T) -> DefinitionOf<T> {
-        return register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+    public func register<T, Arg1, Arg2>(tag tag: Tag? = nil, factory: (Arg1, Arg2) -> T) -> DefinitionOf<T> {
+        return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
     }
     
     /// - seealso: `resolve(tag:_:)`
     public func resolve<T, Arg1, Arg2>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2) -> T {
-        return resolve(tag) { (factory: (Arg1, Arg2) -> T) in factory(arg1, arg2) }
+        return resolve(tag: tag) { (factory: (Arg1, Arg2) -> T) in factory(arg1, arg2) }
     }
     
-    public func register<T, Arg1, Arg2, Arg3>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3) -> T) -> DefinitionOf<T> {
-        return register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+    public func register<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3) -> T) -> DefinitionOf<T> {
+        return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
     }
     
     /// - seealso: `resolve(tag:_:)`
     public func resolve<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> T {
-        return resolve(tag) { (factory: (Arg1, Arg2, Arg3) -> T) in factory(arg1, arg2, arg3) }
+        return resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3) -> T) in factory(arg1, arg2, arg3) }
     }
     
-    public func register<T, Arg1, Arg2, Arg3, Arg4>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4) -> T) -> DefinitionOf<T> {
-        return register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+    public func register<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4) -> T) -> DefinitionOf<T> {
+        return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
     }
     
     /// - seealso: `resolve(tag:_:)`
     public func resolve<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> T {
-        return resolve(tag) { (factory: (Arg1, Arg2, Arg3, Arg4) -> T) in factory(arg1, arg2, arg3, arg4) }
+        return resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4) -> T) in factory(arg1, arg2, arg3, arg4) }
     }
     
-    public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) -> DefinitionOf<T> {
-        return register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+    public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) -> DefinitionOf<T> {
+        return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
     }
     
     /// - seealso: `resolve(tag:_:)`
     public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> T {
-        return resolve(tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) in factory(arg1, arg2, arg3, arg4, arg5) }
+        return resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) in factory(arg1, arg2, arg3, arg4, arg5) }
     }
     
-    public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T) -> DefinitionOf<T> {
-        return register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+    public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T) -> DefinitionOf<T> {
+        return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
     }
     
     /// - seealso: `resolve(tag:_:)`
     public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> T {
-        return resolve(tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T) in factory(arg1, arg2, arg3, arg4, arg5, arg6) }
+        return resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T) in factory(arg1, arg2, arg3, arg4, arg5, arg6) }
     }
 }

--- a/Dip/Dip/RuntimeArguments.swift
+++ b/Dip/Dip/RuntimeArguments.swift
@@ -12,13 +12,18 @@ import Foundation
 
 extension DependencyContainer {
 
+    // MARK: 1 Runtime Argument
+
     /**
      Registers factory that accepts one runtime argument. You can use up to six runtime arguments.
 
-     - parameter tag: The arbitrary tag to associate this factory with when registering with that protocol. Pass `nil` to associate with any tag. Default value is `nil`.
+     - parameter tag: The arbitrary tag to associate this factory with when registering with that protocol.
+                      Pass `nil` to associate with any tag. Default value is `nil`.
      - parameter factory: The factory to register, with return type of protocol you want to register it for
 
-     - note: You can have several factories with different number or types of arguments registered to for same type. When you resolve it container will match the type and tag as well as __number__, __types__ and __order__ of runtime arguments that you pass to `resolve` method.
+     - note: You can have several factories with different number or types of arguments registered to for same type.
+             When you resolve it container will match the type and tag as well as __number__, __types__ and __order__
+             of runtime arguments that you pass to `resolve` method.
 
      - seealso: `register(tag:factory:scope:)`
      */
@@ -27,7 +32,8 @@ extension DependencyContainer {
     }
     
     /**
-     Resolve a dependency with runtime argument. Factories will be matched by tag and the type to resolve as well as __number__, __types__ and __order__ of runtime arguments that you pass to this method.
+     Resolve a dependency with runtime argument. Factories will be matched by tag and the type to resolve as well
+       as __number__, __types__ and __order__ of runtime arguments that you pass to this method.
      
      - parameter tag: The arbitrary tag to look for when resolving this protocol.
      - parameter arg1: First argument to be passed to factory
@@ -38,6 +44,8 @@ extension DependencyContainer {
         return resolve(tag: tag) { (factory: (Arg1) -> T) in factory(arg1) }
     }
 
+    // MARK: 2 Runtime Arguments
+
     /// - seealso: `register(:factory:scope:)`
     public func register<T, Arg1, Arg2>(tag tag: Tag? = nil, factory: (Arg1, Arg2) -> T) -> DefinitionOf<T> {
         return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
@@ -47,7 +55,9 @@ extension DependencyContainer {
     public func resolve<T, Arg1, Arg2>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2) -> T {
         return resolve(tag: tag) { (factory: (Arg1, Arg2) -> T) in factory(arg1, arg2) }
     }
-    
+  
+    // MARK: 3 Runtime Arguments
+
     public func register<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3) -> T) -> DefinitionOf<T> {
         return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
     }
@@ -56,7 +66,9 @@ extension DependencyContainer {
     public func resolve<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> T {
         return resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3) -> T) in factory(arg1, arg2, arg3) }
     }
-    
+  
+    // MARK: 4 Runtime Arguments
+  
     public func register<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4) -> T) -> DefinitionOf<T> {
         return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
     }
@@ -65,7 +77,9 @@ extension DependencyContainer {
     public func resolve<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> T {
         return resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4) -> T) in factory(arg1, arg2, arg3, arg4) }
     }
-    
+  
+    // MARK: 4 Runtime Arguments
+  
     public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) -> DefinitionOf<T> {
         return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
     }
@@ -74,7 +88,9 @@ extension DependencyContainer {
     public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> T {
         return resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) in factory(arg1, arg2, arg3, arg4, arg5) }
     }
-    
+  
+    // MARK: 5 Runtime Arguments
+
     public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T) -> DefinitionOf<T> {
         return register(tag: tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
     }

--- a/Dip/Dip/RuntimeArguments.swift
+++ b/Dip/Dip/RuntimeArguments.swift
@@ -1,0 +1,86 @@
+//
+//  RuntimeArguments.swift
+//  Dip
+//
+//  Created by Ilya Puchka on 04.11.15.
+//  Copyright © 2015 AliSoftware. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - Register/resolve dependencies with runtime arguments
+
+extension DependencyContainer {
+
+    /**
+     Registers factory that accepts one runtime argument. You can use up to six runtime arguments.
+
+     - parameter tag: The arbitrary tag to associate this factory with when registering with that protocol. Pass `nil` to associate with any tag. Default value is `nil`.
+     - parameter factory: The factory to register, with return type of protocol you want to register it for
+
+     - note: You can have several factories with different number or types of arguments registered to for same type. When you resolve it container will match the type and tag as well as __number__, __types__ and __order__ of runtime arguments that you pass to `resolve` method.
+
+     - seealso: `register(tag:factory:scope:)`
+     */
+    public func register<T, Arg1>(tag: Tag? = nil, factory: (Arg1) -> T) -> DefinitionOf<T> {
+        return register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+    }
+    
+    /**
+     Resolve a dependency with runtime argument. Factories will be matched by tag and the type to resolve as well as __number__, __types__ and __order__ of runtime arguments that you pass to this method.
+     
+     - parameter tag: The arbitrary tag to look for when resolving this protocol.
+     - parameter arg1: First argument to be passed to factory
+     
+     - seealso: `resolve(tag:)`
+    */
+    public func resolve<T, Arg1>(tag tag: Tag? = nil, _ arg1: Arg1) -> T {
+        return resolve(tag) { (factory: (Arg1) -> T) in factory(arg1) }
+    }
+
+    /// - seealso: `register(:factory:scope:)`
+    public func register<T, Arg1, Arg2>(tag: Tag? = nil, factory: (Arg1, Arg2) -> T) -> DefinitionOf<T> {
+        return register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+    }
+    
+    /// - seealso: `resolve(tag:_:)`
+    public func resolve<T, Arg1, Arg2>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2) -> T {
+        return resolve(tag) { (factory: (Arg1, Arg2) -> T) in factory(arg1, arg2) }
+    }
+    
+    public func register<T, Arg1, Arg2, Arg3>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3) -> T) -> DefinitionOf<T> {
+        return register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+    }
+    
+    /// - seealso: `resolve(tag:_:)`
+    public func resolve<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) -> T {
+        return resolve(tag) { (factory: (Arg1, Arg2, Arg3) -> T) in factory(arg1, arg2, arg3) }
+    }
+    
+    public func register<T, Arg1, Arg2, Arg3, Arg4>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4) -> T) -> DefinitionOf<T> {
+        return register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+    }
+    
+    /// - seealso: `resolve(tag:_:)`
+    public func resolve<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) -> T {
+        return resolve(tag) { (factory: (Arg1, Arg2, Arg3, Arg4) -> T) in factory(arg1, arg2, arg3, arg4) }
+    }
+    
+    public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) -> DefinitionOf<T> {
+        return register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+    }
+    
+    /// - seealso: `resolve(tag:_:)`
+    public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) -> T {
+        return resolve(tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) in factory(arg1, arg2, arg3, arg4, arg5) }
+    }
+    
+    public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T) -> DefinitionOf<T> {
+        return register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+    }
+    
+    /// - seealso: `resolve(tag:_:)`
+    public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) -> T {
+        return resolve(tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T) in factory(arg1, arg2, arg3, arg4, arg5, arg6) }
+    }
+}

--- a/Dip/DipTests/DipTests.swift
+++ b/Dip/DipTests/DipTests.swift
@@ -13,19 +13,19 @@ protocol Service {
     func getServiceName() -> String
 }
 
+class ServiceImp1: Service {
+    func getServiceName() -> String {
+        return "ServiceImp1"
+    }
+}
+
+class ServiceImp2: Service {
+    func getServiceName() -> String {
+        return "ServiceImp2"
+    }
+}
+
 class DipTests: XCTestCase {
-    
-    class ServiceImp1: Service {
-        func getServiceName() -> String {
-            return "ServiceImp1"
-        }
-    }
-    
-    class ServiceImp2: Service {
-        func getServiceName() -> String {
-            return "ServiceImp2"
-        }
-    }
     
     let container = DependencyContainer()
     
@@ -50,7 +50,7 @@ class DipTests: XCTestCase {
         container.register("service") { ServiceImp1() as Service }
 
         //when
-        let serviceInstance = container.resolve("service") as Service
+        let serviceInstance = container.resolve(tag: "service") as Service
         
         //then
         XCTAssertTrue(serviceInstance is ServiceImp1)
@@ -62,8 +62,8 @@ class DipTests: XCTestCase {
         container.register("service2") { ServiceImp2() as Service }
         
         //when
-        let service1Instance = container.resolve("service1") as Service
-        let service2Instance = container.resolve("service2") as Service
+        let service1Instance = container.resolve(tag: "service1") as Service
+        let service2Instance = container.resolve(tag: "service2") as Service
         
         //then
         XCTAssertTrue(service1Instance is ServiceImp1)

--- a/Dip/DipTests/DipTests.swift
+++ b/Dip/DipTests/DipTests.swift
@@ -47,7 +47,7 @@ class DipTests: XCTestCase {
     
     func testThatItResolvesInstanceRegisteredWithTag() {
         //given
-        container.register("service") { ServiceImp1() as Service }
+        container.register(tag: "service") { ServiceImp1() as Service }
 
         //when
         let serviceInstance = container.resolve(tag: "service") as Service
@@ -58,8 +58,8 @@ class DipTests: XCTestCase {
 
     func testThatItResolvesDifferentInstancesRegisteredForDifferentTags() {
         //given
-        container.register("service1") { ServiceImp1() as Service }
-        container.register("service2") { ServiceImp2() as Service }
+        container.register(tag: "service1") { ServiceImp1() as Service }
+        container.register(tag: "service2") { ServiceImp2() as Service }
         
         //when
         let service1Instance = container.resolve(tag: "service1") as Service

--- a/Dip/DipTests/RuntimeArgumentsTests.swift
+++ b/Dip/DipTests/RuntimeArgumentsTests.swift
@@ -200,7 +200,8 @@ class RuntimeArgumentsTests: XCTestCase {
         container.register { (port: Int, url: NSURL!) in ServiceImp3(name: name3, baseURL: url, port: port) as Service }
         
         //when
-        let service1 = container.resolve(80, NSURL(string: "http://example.com")!) as Service
+        let url: NSURL = NSURL(string: "http://example.com")!
+        let service1 = container.resolve(80, url) as Service
         let service2 = container.resolve(80, NSURL(string: "http://example.com")) as Service
         
         let service3 = container.resolve(80, NSURL(string: "http://example.com")! as NSURL!) as Service

--- a/Dip/DipTests/RuntimeArgumentsTests.swift
+++ b/Dip/DipTests/RuntimeArgumentsTests.swift
@@ -1,0 +1,182 @@
+//
+//  RuntimeArgumentsTests.swift
+//  Dip
+//
+//  Created by Ilya Puchka on 04.11.15.
+//  Copyright © 2015 AliSoftware. All rights reserved.
+//
+
+import XCTest
+@testable import Dip
+
+class RuntimeArgumentsTests: XCTestCase {
+    
+    let container = DependencyContainer()
+    
+    override func setUp() {
+        super.setUp()
+        container.reset()
+    }
+    
+    func testThatItResolvesInstanceWithOneArgument() {
+        //given
+        let arg1 = 1
+        container.register { (a1: Int) -> Service in
+            XCTAssertEqual(a1, arg1)
+            return ServiceImp1()
+        }
+        
+        //when
+        let service = container.resolve(arg1) as Service
+        
+        //then
+        XCTAssertTrue(service is ServiceImp1)
+    }
+    
+    func testThatItResolvesInstanceWithTwoArguments() {
+        //given
+        let arg1 = 1, arg2 = 2
+        container.register { (a1: Int, a2: Int) -> Service in
+            XCTAssertEqual(a1, arg1)
+            XCTAssertEqual(a2, arg2)
+            return ServiceImp1()
+        }
+        
+        //when
+        let service = container.resolve(arg1, arg2) as Service
+        
+        //then
+        XCTAssertTrue(service is ServiceImp1)
+    }
+
+    func testThatItResolvesInstanceWithThreeArguments() {
+        let arg1 = 1, arg2 = 2, arg3 = 3
+        container.register { (a1: Int, a2: Int, a3: Int) -> Service in
+            XCTAssertEqual(a1, arg1)
+            XCTAssertEqual(a2, arg2)
+            XCTAssertEqual(a3, arg3)
+            return ServiceImp1()
+        }
+        
+        //when
+        let service = container.resolve(arg1, arg2, arg3) as Service
+        
+        //then
+        XCTAssertTrue(service is ServiceImp1)
+    }
+    
+    func testThatItResolvesInstanceWithFourArguments() {
+        let arg1 = 1, arg2 = 2, arg3 = 3, arg4 = 4
+        container.register { (a1: Int, a2: Int, a3: Int, a4: Int) -> Service in
+            XCTAssertEqual(a1, arg1)
+            XCTAssertEqual(a2, arg2)
+            XCTAssertEqual(a3, arg3)
+            XCTAssertEqual(a4, arg4)
+            return ServiceImp1()
+        }
+        
+        //when
+        let service = container.resolve(arg1, arg2, arg3, arg4) as Service
+        
+        //then
+        XCTAssertTrue(service is ServiceImp1)
+    }
+    
+    func testThatItResolvesInstanceWithFiveArguments() {
+        let arg1 = 1, arg2 = 2, arg3 = 3, arg4 = 4, arg5 = 5
+        container.register { (a1: Int, a2: Int, a3: Int, a4: Int, a5: Int) -> Service in
+            XCTAssertEqual(a1, arg1)
+            XCTAssertEqual(a2, arg2)
+            XCTAssertEqual(a3, arg3)
+            XCTAssertEqual(a4, arg4)
+            XCTAssertEqual(a5, arg5)
+            return ServiceImp1()
+        }
+        
+        //when
+        let service = container.resolve(arg1, arg2, arg3, arg4, arg5) as Service
+        
+        //then
+        XCTAssertTrue(service is ServiceImp1)
+    }
+    
+    func testThatItResolvesInstanceWithSixArguments() {
+        let arg1 = 1, arg2 = 2, arg3 = 3, arg4 = 4, arg5 = 5, arg6 = 6
+        container.register { (a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int) -> Service in
+            XCTAssertEqual(a1, arg1)
+            XCTAssertEqual(a2, arg2)
+            XCTAssertEqual(a3, arg3)
+            XCTAssertEqual(a4, arg4)
+            XCTAssertEqual(a5, arg5)
+            XCTAssertEqual(a6, arg6)
+            return ServiceImp1()
+        }
+        
+        //when
+        let service = container.resolve(arg1, arg2, arg3, arg4, arg5, arg6) as Service
+        
+        //then
+        XCTAssertTrue(service is ServiceImp1)
+    }
+    
+    func testThatItRegistersDifferentFactoriesForDifferentNumberOfArguments() {
+        //given
+        let arg1 = 1, arg2 = 2
+        container.register { (a1: Int) in ServiceImp1() as Service }
+        container.register { (a1: Int, a2: Int) in ServiceImp2() as Service }
+        
+        //when
+        let service1 = container.resolve(arg1) as Service
+        let service2 = container.resolve(arg1, arg2) as Service
+        
+        //then
+        XCTAssertTrue(service1 is ServiceImp1)
+        XCTAssertTrue(service2 is ServiceImp2)
+    }
+    
+    func testThatItRegistersDifferentFactoriesForDifferentTypesOfArguments() {
+        //given
+        let arg1 = 1, arg2 = "string"
+        container.register { (a1: Int) in ServiceImp1() as Service }
+        container.register { (a1: String) in ServiceImp2() as Service }
+        
+        //when
+        let service1 = container.resolve(arg1) as Service
+        let service2 = container.resolve(arg2) as Service
+        
+        //then
+        XCTAssertTrue(service1 is ServiceImp1)
+        XCTAssertTrue(service2 is ServiceImp2)
+    }
+    
+    func testThatItRegistersDifferentFactoriesForDifferentOrderOfArguments() {
+        //given
+        let arg1 = 1, arg2 = "string"
+        container.register { (a1: Int, a2: String) in ServiceImp1() as Service }
+        container.register { (a1: String, a2: Int) in ServiceImp2() as Service }
+        
+        //when
+        let service1 = container.resolve(arg1, arg2) as Service
+        let service2 = container.resolve(arg2, arg1) as Service
+        
+        //then
+        XCTAssertTrue(service1 is ServiceImp1)
+        XCTAssertTrue(service2 is ServiceImp2)
+    }
+    
+    func testThatNewRegistrationWithSameArgumentsOverridesPreviousRegistration() {
+        //given
+        let arg1 = 1, arg2 = 2
+        container.register { (a1: Int, a2: Int) in ServiceImp1() as Service }
+        let service1 = container.resolve(arg1, arg2) as Service
+        
+        //when
+        container.register { (a1: Int, a2: Int) in ServiceImp2() as Service }
+        let service2 = container.resolve(arg1, arg2) as Service
+        
+        //then
+        XCTAssertTrue(service1 is ServiceImp1)
+        XCTAssertTrue(service2 is ServiceImp2)
+    }
+
+}

--- a/Dip/DipTests/RuntimeArgumentsTests.swift
+++ b/Dip/DipTests/RuntimeArgumentsTests.swift
@@ -9,6 +9,19 @@
 import XCTest
 @testable import Dip
 
+class ServiceImp3: Service {
+    
+    let name: String
+    
+    init(name: String, baseURL: NSURL, port: Int) {
+        self.name = name
+    }
+    
+    func getServiceName() -> String {
+        return name
+    }
+}
+
 class RuntimeArgumentsTests: XCTestCase {
     
     let container = DependencyContainer()
@@ -177,6 +190,27 @@ class RuntimeArgumentsTests: XCTestCase {
         //then
         XCTAssertTrue(service1 is ServiceImp1)
         XCTAssertTrue(service2 is ServiceImp2)
+    }
+    
+    func testThatDifferentFactoriesRegisteredIfArgumentIsOptional() {
+        //given
+        let name1 = "1", name2 = "2", name3 = "3"
+        container.register { (port: Int, url: NSURL) in ServiceImp3(name: name1, baseURL: url, port: port) as Service }
+        container.register { (port: Int, url: NSURL?) in ServiceImp3(name: name2, baseURL: url!, port: port) as Service }
+        container.register { (port: Int, url: NSURL!) in ServiceImp3(name: name3, baseURL: url, port: port) as Service }
+        
+        //when
+        let service1 = container.resolve(80, NSURL(string: "http://example.com")!) as Service
+        let service2 = container.resolve(80, NSURL(string: "http://example.com")) as Service
+        
+        let service3 = container.resolve(80, NSURL(string: "http://example.com")! as NSURL!) as Service
+        let service4 = container.resolve(80, NSURL(string: "http://example.com")!) as Service
+        
+        //then
+        XCTAssertEqual(service1.getServiceName(), name1)
+        XCTAssertEqual(service2.getServiceName(), name2)
+        XCTAssertEqual(service3.getServiceName(), name3)
+        XCTAssertEqual(service4.getServiceName(), name1) //implicitly unwrapped optional parameter is the same as not optional parameter
     }
 
 }

--- a/Example/DipSampleApp.xcodeproj/project.pbxproj
+++ b/Example/DipSampleApp.xcodeproj/project.pbxproj
@@ -60,7 +60,6 @@
 		0900123F1BC704C60079C600 /* Person.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Person.swift; sourceTree = "<group>"; };
 		090012411BC7059E0079C600 /* Starship.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Starship.swift; sourceTree = "<group>"; };
 		090012431BC708A00079C600 /* DummyStarshipProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DummyStarshipProvider.swift; sourceTree = "<group>"; };
-		097D52FE1BC18A09006C893C /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../CHANGELOG.md; sourceTree = "<group>"; };
 		0990225F1BC123C000E76F43 /* DipSampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DipSampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		099022611BC123C000E76F43 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		099022681BC123C000E76F43 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -86,13 +85,10 @@
 		607FACE51AFB9204008FA782 /* DipSampleAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DipSampleAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACEB1AFB9204008FA782 /* SWAPIPersonProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SWAPIPersonProviderTests.swift; sourceTree = "<group>"; };
-		64B6CB26CB93DFD18565BB72 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		6AB71DAFECF410F2FB12A44C /* Pods-DipSampleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DipSampleApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DipSampleApp/Pods-DipSampleApp.debug.xcconfig"; sourceTree = "<group>"; };
-		9B78063878AFC700C876DEE9 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		A2C6C3A848EB4F91A56B8CE2 /* Pods_DipSampleAppTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DipSampleAppTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B16085421B606723B72DE694 /* Pods-DipSampleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DipSampleApp.release.xcconfig"; path = "Pods/Target Support Files/Pods-DipSampleApp/Pods-DipSampleApp.release.xcconfig"; sourceTree = "<group>"; };
 		F0136B7190E952E9A9D8BF64 /* Pods-DipSampleAppTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DipSampleAppTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DipSampleAppTests/Pods-DipSampleAppTests.debug.xcconfig"; sourceTree = "<group>"; };
-		FDB7C1D2EFEC1BA700762782 /* Dip.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Dip.podspec; path = ../Dip.podspec; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -218,7 +214,6 @@
 		607FACC71AFB9204008FA782 = {
 			isa = PBXGroup;
 			children = (
-				607FACF51AFB993E008FA782 /* Podspec Metadata */,
 				099022601BC123C000E76F43 /* DipSampleApp */,
 				607FACE81AFB9204008FA782 /* Tests */,
 				607FACD11AFB9204008FA782 /* Products */,
@@ -253,17 +248,6 @@
 				607FACEA1AFB9204008FA782 /* Info.plist */,
 			);
 			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		607FACF51AFB993E008FA782 /* Podspec Metadata */ = {
-			isa = PBXGroup;
-			children = (
-				FDB7C1D2EFEC1BA700762782 /* Dip.podspec */,
-				64B6CB26CB93DFD18565BB72 /* README.md */,
-				097D52FE1BC18A09006C893C /* CHANGELOG.md */,
-				9B78063878AFC700C876DEE9 /* LICENSE */,
-			);
-			name = "Podspec Metadata";
 			sourceTree = "<group>";
 		};
 		B10E0DA4AD9E022CCA0B272F /* Pods */ = {

--- a/Example/DipSampleApp.xcworkspace/contents.xcworkspacedata
+++ b/Example/DipSampleApp.xcworkspace/contents.xcworkspacedata
@@ -7,4 +7,20 @@
    <FileRef
       location = "group:Pods/Pods.xcodeproj">
    </FileRef>
+   <Group
+      location = "group:"
+      name = "Podspec Metadata">
+      <FileRef
+         location = "group:../Dip.podspec">
+      </FileRef>
+      <FileRef
+         location = "group:../README.md">
+      </FileRef>
+      <FileRef
+         location = "group:../CHANGELOG.md">
+      </FileRef>
+      <FileRef
+         location = "group:../LICENSE">
+      </FileRef>
+   </Group>
 </Workspace>

--- a/Example/DipSampleApp/DependencyContainers.swift
+++ b/Example/DipSampleApp/DependencyContainers.swift
@@ -34,7 +34,7 @@ let providerDependencies = DependencyContainer() { dip in
         
         // 1) Register the PersonProviderAPI singleton, one generic and one specific for a specific personID
         dip.register(instance: DummyPilotProvider() as PersonProviderAPI)
-        dip.register(0, instance: PlistPersonProvider(plist: "mainPilot") as PersonProviderAPI)
+        dip.register(tag: 0, instance: PlistPersonProvider(plist: "mainPilot") as PersonProviderAPI)
         
     } else {
         
@@ -47,7 +47,7 @@ let providerDependencies = DependencyContainer() { dip in
 
         // 2) Register the StarshipProviderAPI factories, one generic and one specific for a specific starshipID
         dip.register() { HardCodedStarshipProvider() as StarshipProviderAPI }
-        dip.register(0) { DummyStarshipProvider(pilotName: "Main Pilot") as StarshipProviderAPI }
+        dip.register(tag: 0) { DummyStarshipProvider(pilotName: "Main Pilot") as StarshipProviderAPI }
         
     } else {
         

--- a/Example/DipSampleApp/Providers/SWAPIPersonProvider.swift
+++ b/Example/DipSampleApp/Providers/SWAPIPersonProvider.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct SWAPIPersonProvider : PersonProviderAPI {
-    let ws = wsDependencies.resolve(WebService.PersonWS.tag) as NetworkLayer
+    let ws = wsDependencies.resolve(tag: WebService.PersonWS.tag) as NetworkLayer
     
     func fetchIDs(completion: [Int] -> Void) {
         ws.request("people") { response in

--- a/Example/DipSampleApp/Providers/SWAPIStarshipProvider.swift
+++ b/Example/DipSampleApp/Providers/SWAPIStarshipProvider.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct SWAPIStarshipProvider : StarshipProviderAPI {
-    let ws = wsDependencies.resolve(WebService.StarshipWS.tag) as NetworkLayer
+    let ws = wsDependencies.resolve(tag: WebService.StarshipWS.tag) as NetworkLayer
     
     func fetchIDs(completion: [Int] -> Void) {
         ws.request("starships") { response in

--- a/Example/DipSampleApp/ViewControllers/PersonListViewController.swift
+++ b/Example/DipSampleApp/ViewControllers/PersonListViewController.swift
@@ -17,7 +17,7 @@ class PersonListViewController: UITableViewController, FetchableTrait {
         return provider.fetchIDs(completion)
     }
     func fetchOne(personID: Int, completion: Person? -> Void) {
-        let provider = providerDependencies.resolve(.Int(personID)) as PersonProviderAPI
+        let provider = providerDependencies.resolve(tag: .Int(personID)) as PersonProviderAPI
         return provider.fetch(personID, completion: completion)
     }
     

--- a/Example/DipSampleApp/ViewControllers/StarshipListViewController.swift
+++ b/Example/DipSampleApp/ViewControllers/StarshipListViewController.swift
@@ -14,7 +14,7 @@ class StarshipListViewController : UITableViewController, FetchableTrait {
     var batchRequestID = 0
     
     private func provider(tag:Int?) -> StarshipProviderAPI {
-        return providerDependencies.resolve(tag.flatMap { .Int($0) })
+        return providerDependencies.resolve(tag: tag.flatMap { .Int($0) })
     }
     
     func fetchIDs(completion: [Int] -> Void) {

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -8,17 +8,19 @@
 
 /* Begin PBXBuildFile section */
 		099856F2543927A515C56C9708296854 /* Pods-DipSampleAppTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D640916E3C76B06636F471C09E1AE293 /* Pods-DipSampleAppTests-dummy.m */; };
+		1F6622E0485001E3E75A39AA3775FC53 /* Info.plist in Sources */ = {isa = PBXBuildFile; fileRef = 5DE643661AC9167FB3350ADBA77B4055 /* Info.plist */; };
 		233F81BF5C5FCE081EE3E4963D0B28CD /* Pods-DipSampleApp-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DD482CB3D537E300A96B01CD5F2B3738 /* Pods-DipSampleApp-dummy.m */; };
-		2F64BEC850F9A4905E50910B72E9F1E9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E4E89230EF59BC255123B67864ACF77 /* Foundation.framework */; };
+		23AEADB45C682DD49F1EB72970785926 /* Dip-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 68E64E759BA293C84A04D092FC7EFF2C /* Dip-dummy.m */; };
+		30E792A3E5382D00A404F3339DC7090E /* Dip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E99CDDFD02616B09336842D37F0A68B /* Dip.swift */; };
 		48A288EBBEA21F205CC691D18EFE359E /* Pods-DipSampleAppTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = F51778BB3CD84C08292B7F771A60CC3D /* Pods-DipSampleAppTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		598949CC3DD0DD2142DFA9759D331DB6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E4E89230EF59BC255123B67864ACF77 /* Foundation.framework */; };
 		5AED80C9C2DE389DDCD7688C4AA1001C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E4E89230EF59BC255123B67864ACF77 /* Foundation.framework */; };
-		8847DBD3BDC2D2B587DFADA898A3780E /* Dip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A6D41FE51683ED837A9F737B9060F6 /* Dip.swift */; };
-		89837ADE5AE00A0D41FFD17C9C34B7AD /* Info.plist in Sources */ = {isa = PBXBuildFile; fileRef = 2750460A065566EB63F4B6ECC9C21018 /* Info.plist */; };
-		9948DBE743657ACDF475FB20DD8E829C /* Dip.h in Headers */ = {isa = PBXBuildFile; fileRef = B98D2FC800A748833228BDF1644A8DD2 /* Dip.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A2B67837356326EFA1563322850085DA /* Dip-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B701F07F9BDFB886D9F6D26A93362645 /* Dip-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6EAC2D85E7719D307B9B2FA805869D4D /* RuntimeArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8EC1FBAAC1B3B5596A78DE613EBF5B1 /* RuntimeArguments.swift */; };
+		7C7B8DA8211D8357BA0FBA0B80445E7C /* Definition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8830519F102604674B9DE5EE31B40C9C /* Definition.swift */; };
+		93B846A1BBFFBE20652BA959B5B7A677 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E4E89230EF59BC255123B67864ACF77 /* Foundation.framework */; };
+		9B09B358A79E606DFB7A132ED3E9D03D /* Dip.h in Headers */ = {isa = PBXBuildFile; fileRef = 41AEC7875DC1F4D8AEFF4550F27EF640 /* Dip.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE06FE77C65C0BE8BDD6AFB33EAD328F /* Pods-DipSampleApp-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C80266778E400B784EE6342E355D95D9 /* Pods-DipSampleApp-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FA0A8B1E47D7CA61331DD389F7D401EB /* Dip-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 68E64E759BA293C84A04D092FC7EFF2C /* Dip-dummy.m */; };
+		DC3DA55B7006545FAF7485B775B712B3 /* Dip-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B701F07F9BDFB886D9F6D26A93362645 /* Dip-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -26,39 +28,41 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 5CCEBDEA9B8F04599FBC0B121ADA0BF0;
+			remoteGlobalIDString = 37582D0F218D3CF3721E51FD25D9193F;
 			remoteInfo = Dip;
 		};
 		62848E69B71441AB05941E7E2F09E1D8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 5CCEBDEA9B8F04599FBC0B121ADA0BF0;
+			remoteGlobalIDString = 37582D0F218D3CF3721E51FD25D9193F;
 			remoteInfo = Dip;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		04A6D41FE51683ED837A9F737B9060F6 /* Dip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Dip.swift; sourceTree = "<group>"; };
 		0B105A8A1355B5C7DDFA58A6F4674002 /* Pods-DipSampleApp-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-DipSampleApp-acknowledgements.markdown"; sourceTree = "<group>"; };
 		0EE787587CFA67E6E14EA24B6EA28208 /* Pods-DipSampleAppTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-DipSampleAppTests.modulemap"; sourceTree = "<group>"; };
 		1271938A51911D4908DD6F3A684DE9CD /* Dip.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Dip.modulemap; sourceTree = "<group>"; };
 		186F814F5F2DC558E1ECBFBA3090B3C6 /* Pods-DipSampleAppTests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-DipSampleAppTests-resources.sh"; sourceTree = "<group>"; };
-		2750460A065566EB63F4B6ECC9C21018 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2ABA441952D14F5DE39FEF5D3F04A3B9 /* Pods-DipSampleApp-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-DipSampleApp-resources.sh"; sourceTree = "<group>"; };
 		3E4E89230EF59BC255123B67864ACF77 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		41AEC7875DC1F4D8AEFF4550F27EF640 /* Dip.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Dip.h; sourceTree = "<group>"; };
 		443EEE2C174A68E20605173364687495 /* Pods-DipSampleAppTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-DipSampleAppTests-frameworks.sh"; sourceTree = "<group>"; };
 		45DC2C82D205D437A691EF6EF8C263F9 /* Pods-DipSampleApp-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-DipSampleApp-frameworks.sh"; sourceTree = "<group>"; };
 		515EF3CDABB6913B658C164B0FCCA580 /* Pods-DipSampleApp-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-DipSampleApp-acknowledgements.plist"; sourceTree = "<group>"; };
+		5DE643661AC9167FB3350ADBA77B4055 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		603B64FEE671F6729781081BD4C12A77 /* Dip-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Dip-prefix.pch"; sourceTree = "<group>"; };
 		62C72F4FC938BE50B3863D978309822A /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		66DEF8FDB11707D2CDFCBF8DFCE7DCE4 /* Pods-DipSampleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-DipSampleApp.release.xcconfig"; sourceTree = "<group>"; };
 		68E64E759BA293C84A04D092FC7EFF2C /* Dip-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Dip-dummy.m"; sourceTree = "<group>"; };
 		6FC8E55DEB24159F41041EF0C4391581 /* Pods-DipSampleAppTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-DipSampleAppTests.release.xcconfig"; sourceTree = "<group>"; };
 		86CF59AE0A127EDDC47F6E04CE3F0FFC /* Dip.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Dip.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8830519F102604674B9DE5EE31B40C9C /* Definition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Definition.swift; sourceTree = "<group>"; };
+		8E99CDDFD02616B09336842D37F0A68B /* Dip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Dip.swift; sourceTree = "<group>"; };
 		934DA76CD00649E6F2EF8C3329CBB228 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B701F07F9BDFB886D9F6D26A93362645 /* Dip-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Dip-umbrella.h"; sourceTree = "<group>"; };
-		B98D2FC800A748833228BDF1644A8DD2 /* Dip.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Dip.h; sourceTree = "<group>"; };
+		B8EC1FBAAC1B3B5596A78DE613EBF5B1 /* RuntimeArguments.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RuntimeArguments.swift; sourceTree = "<group>"; };
 		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		C80266778E400B784EE6342E355D95D9 /* Pods-DipSampleApp-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-DipSampleApp-umbrella.h"; sourceTree = "<group>"; };
 		D45FA9D59225B11F31873952AB550401 /* Pods_DipSampleAppTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DipSampleAppTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -76,19 +80,19 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		4F49DBAD2539447C7E37A6D38F94CFAB /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				2F64BEC850F9A4905E50910B72E9F1E9 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		900C5E0716F1CDD85E272A21A7BC6C71 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				5AED80C9C2DE389DDCD7688C4AA1001C /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9E3C9B8265CE97200C37BC2E33220706 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				93B846A1BBFFBE20652BA959B5B7A677 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -120,7 +124,7 @@
 		0E89E082BF9A4869E0DC309BF11F4CCC /* Dip */ = {
 			isa = PBXGroup;
 			children = (
-				DB424F8973CBD44D0BF681963D7B1050 /* Dip */,
+				A204C9F086954B257E03CD13C545EA05 /* Dip */,
 				0E63CF4D77C0628BE4A91A3CD7DF1E8C /* Support Files */,
 			);
 			name = Dip;
@@ -163,16 +167,6 @@
 			path = "Target Support Files/Pods-DipSampleAppTests";
 			sourceTree = "<group>";
 		};
-		56655CC9284949923D43BF8CFD2597CA /* Dip */ = {
-			isa = PBXGroup;
-			children = (
-				B98D2FC800A748833228BDF1644A8DD2 /* Dip.h */,
-				04A6D41FE51683ED837A9F737B9060F6 /* Dip.swift */,
-				2750460A065566EB63F4B6ECC9C21018 /* Info.plist */,
-			);
-			path = Dip;
-			sourceTree = "<group>";
-		};
 		7DB346D0F39D3F0E887471402A8071AB = {
 			isa = PBXGroup;
 			children = (
@@ -193,6 +187,26 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
+		A204C9F086954B257E03CD13C545EA05 /* Dip */ = {
+			isa = PBXGroup;
+			children = (
+				B453CC571C8955073D0F6AA602CE5600 /* Dip */,
+			);
+			path = Dip;
+			sourceTree = "<group>";
+		};
+		B453CC571C8955073D0F6AA602CE5600 /* Dip */ = {
+			isa = PBXGroup;
+			children = (
+				8830519F102604674B9DE5EE31B40C9C /* Definition.swift */,
+				41AEC7875DC1F4D8AEFF4550F27EF640 /* Dip.h */,
+				8E99CDDFD02616B09336842D37F0A68B /* Dip.swift */,
+				5DE643661AC9167FB3350ADBA77B4055 /* Info.plist */,
+				B8EC1FBAAC1B3B5596A78DE613EBF5B1 /* RuntimeArguments.swift */,
+			);
+			path = Dip;
+			sourceTree = "<group>";
+		};
 		BC3CA7F9E30CC8F7E2DD044DD34432FC /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -207,14 +221,6 @@
 				3E4E89230EF59BC255123B67864ACF77 /* Foundation.framework */,
 			);
 			name = iOS;
-			sourceTree = "<group>";
-		};
-		DB424F8973CBD44D0BF681963D7B1050 /* Dip */ = {
-			isa = PBXGroup;
-			children = (
-				56655CC9284949923D43BF8CFD2597CA /* Dip */,
-			);
-			path = Dip;
 			sourceTree = "<group>";
 		};
 		EE8B2CF9D7F56AFB6B5612046C6446DE /* Pods-DipSampleApp */ = {
@@ -246,20 +252,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4BB0E7F517CAD22071FF9D4E41C1EB18 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DC3DA55B7006545FAF7485B775B712B3 /* Dip-umbrella.h in Headers */,
+				9B09B358A79E606DFB7A132ED3E9D03D /* Dip.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BBAC4F3AB5D36D3D0D5D75D8B850C13E /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				CE06FE77C65C0BE8BDD6AFB33EAD328F /* Pods-DipSampleApp-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D2B3DAE9EBA88B793447D7564DF3879D /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A2B67837356326EFA1563322850085DA /* Dip-umbrella.h in Headers */,
-				9948DBE743657ACDF475FB20DD8E829C /* Dip.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -284,6 +290,23 @@
 			productReference = D45FA9D59225B11F31873952AB550401 /* Pods_DipSampleAppTests.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		37582D0F218D3CF3721E51FD25D9193F /* Dip */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 76B46CB2CDE5A40E7912E14698829405 /* Build configuration list for PBXNativeTarget "Dip" */;
+			buildPhases = (
+				11D93A3C184B3A157DF48D368947A637 /* Sources */,
+				9E3C9B8265CE97200C37BC2E33220706 /* Frameworks */,
+				4BB0E7F517CAD22071FF9D4E41C1EB18 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Dip;
+			productName = Dip;
+			productReference = 86CF59AE0A127EDDC47F6E04CE3F0FFC /* Dip.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		3A53F07A7DBB3101BFCAD512E679F62C /* Pods-DipSampleApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B70E7A5902F5B0D610680BC908B731F3 /* Build configuration list for PBXNativeTarget "Pods-DipSampleApp" */;
@@ -300,23 +323,6 @@
 			name = "Pods-DipSampleApp";
 			productName = "Pods-DipSampleApp";
 			productReference = D521C5542FF9BD58275D2804314E8BAE /* Pods_DipSampleApp.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		5CCEBDEA9B8F04599FBC0B121ADA0BF0 /* Dip */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 76CBA65FFEA5DEC2618D85D217CF0FD2 /* Build configuration list for PBXNativeTarget "Dip" */;
-			buildPhases = (
-				C26A92FF770F72CFD4508CFFFFFCC9CE /* Sources */,
-				4F49DBAD2539447C7E37A6D38F94CFAB /* Frameworks */,
-				D2B3DAE9EBA88B793447D7564DF3879D /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Dip;
-			productName = Dip;
-			productReference = 86CF59AE0A127EDDC47F6E04CE3F0FFC /* Dip.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -340,7 +346,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				5CCEBDEA9B8F04599FBC0B121ADA0BF0 /* Dip */,
+				37582D0F218D3CF3721E51FD25D9193F /* Dip */,
 				3A53F07A7DBB3101BFCAD512E679F62C /* Pods-DipSampleApp */,
 				2911F25084A970BBA26DBF67386293DA /* Pods-DipSampleAppTests */,
 			);
@@ -348,6 +354,18 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
+		11D93A3C184B3A157DF48D368947A637 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7C7B8DA8211D8357BA0FBA0B80445E7C /* Definition.swift in Sources */,
+				23AEADB45C682DD49F1EB72970785926 /* Dip-dummy.m in Sources */,
+				30E792A3E5382D00A404F3339DC7090E /* Dip.swift in Sources */,
+				1F6622E0485001E3E75A39AA3775FC53 /* Info.plist in Sources */,
+				6EAC2D85E7719D307B9B2FA805869D4D /* RuntimeArguments.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A943C34198589805B647072D0565220C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -364,29 +382,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C26A92FF770F72CFD4508CFFFFFCC9CE /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				FA0A8B1E47D7CA61331DD389F7D401EB /* Dip-dummy.m in Sources */,
-				8847DBD3BDC2D2B587DFADA898A3780E /* Dip.swift in Sources */,
-				89837ADE5AE00A0D41FFD17C9C34B7AD /* Info.plist in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		08B3A76291243CD956881BEA5AF90311 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Dip;
-			target = 5CCEBDEA9B8F04599FBC0B121ADA0BF0 /* Dip */;
+			target = 37582D0F218D3CF3721E51FD25D9193F /* Dip */;
 			targetProxy = 4B568E9DCE2F505832F46D1BF0F58305 /* PBXContainerItemProxy */;
 		};
 		394A3171C70875A58CBC5E1A1DC019D7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Dip;
-			target = 5CCEBDEA9B8F04599FBC0B121ADA0BF0 /* Dip */;
+			target = 37582D0F218D3CF3721E51FD25D9193F /* Dip */;
 			targetProxy = 62848E69B71441AB05941E7E2F09E1D8 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -423,35 +431,7 @@
 			};
 			name = Debug;
 		};
-		375D70C445A17B8C5855ED01FC7BF9EB /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = F117439E585C1CCF61B5E76F24C02259 /* Dip.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Dip/Dip-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Dip/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Dip/Dip.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Dip;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		5754BC9A6ADCCB857016EECAB28D50D5 /* Release */ = {
+		30E508032152F9376CADCB8067B79AE4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F117439E585C1CCF61B5E76F24C02259 /* Dip.xcconfig */;
 			buildSettings = {
@@ -578,6 +558,34 @@
 			};
 			name = Release;
 		};
+		CA27093EA4B65009FE5E1E0B4C6A3779 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F117439E585C1CCF61B5E76F24C02259 /* Dip.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Dip/Dip-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Dip/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Dip/Dip.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = Dip;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		CBDDB14779D5F8C01DB8F4A9A013509C /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 66DEF8FDB11707D2CDFCBF8DFCE7DCE4 /* Pods-DipSampleApp.release.xcconfig */;
@@ -654,11 +662,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		76CBA65FFEA5DEC2618D85D217CF0FD2 /* Build configuration list for PBXNativeTarget "Dip" */ = {
+		76B46CB2CDE5A40E7912E14698829405 /* Build configuration list for PBXNativeTarget "Dip" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				375D70C445A17B8C5855ED01FC7BF9EB /* Debug */,
-				5754BC9A6ADCCB857016EECAB28D50D5 /* Release */,
+				CA27093EA4B65009FE5E1E0B4C6A3779 /* Debug */,
+				30E508032152F9376CADCB8067B79AE4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Dip.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Dip.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '2389405F48C0C36D1915DFB9'
+               BlueprintIdentifier = 'B3DE121DE68E018FAB164604'
                BlueprintName = 'Dip'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'Dip.framework'>

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Dip.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Dip.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '9F8A001F86B722B7937E5DF6'
+               BlueprintIdentifier = '2389405F48C0C36D1915DFB9'
                BlueprintName = 'Dip'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'Dip.framework'>

--- a/Example/Tests/SWAPIPersonProviderTests.swift
+++ b/Example/Tests/SWAPIPersonProviderTests.swift
@@ -23,7 +23,7 @@ class SWAPIPersonProviderTests: XCTestCase {
     
     func testFetchPersonIDs() {
         let mock = NetworkMock(json: ["results": [fakePerson1, fakePerson2]])
-        wsDependencies.register(WebService.PersonWS.tag, instance: mock as NetworkLayer)
+        wsDependencies.register(tag: WebService.PersonWS.tag, instance: mock as NetworkLayer)
         
         let provider = SWAPIPersonProvider()
         provider.fetchIDs { personIDs in
@@ -38,7 +38,7 @@ class SWAPIPersonProviderTests: XCTestCase {
     func testFetchOnePerson() {
         
         let mock = NetworkMock(json: fakePerson1)
-        wsDependencies.register(WebService.PersonWS.tag, instance: mock as NetworkLayer)
+        wsDependencies.register(tag: WebService.PersonWS.tag, instance: mock as NetworkLayer)
         
         let provider = SWAPIPersonProvider()
         provider.fetch(1) { person in
@@ -58,7 +58,7 @@ class SWAPIPersonProviderTests: XCTestCase {
     func testFetchInvalidPerson() {
         let json = ["error":"whoops"]
         let mock = NetworkMock(json: json)
-        wsDependencies.register(WebService.PersonWS.tag, instance: mock as NetworkLayer)
+        wsDependencies.register(tag: WebService.PersonWS.tag, instance: mock as NetworkLayer)
         
         let provider = SWAPIPersonProvider()
         provider.fetch(12) { person in

--- a/Example/Tests/SWAPIStarshipProviderTests.swift
+++ b/Example/Tests/SWAPIStarshipProviderTests.swift
@@ -23,7 +23,7 @@ class SWAPIStarshipProviderTests: XCTestCase {
     
     func testFetchStarshipIDs() {
         let mock = NetworkMock(json: ["results": [fakeShip1, fakeShip2]])
-        wsDependencies.register(WebService.StarshipWS.tag, instance: mock as NetworkLayer)
+        wsDependencies.register(tag: WebService.StarshipWS.tag, instance: mock as NetworkLayer)
         
         let provider = SWAPIStarshipProvider()
         provider.fetchIDs { shipIDs in
@@ -38,7 +38,7 @@ class SWAPIStarshipProviderTests: XCTestCase {
     func testFetchOneStarship() {
         
         let mock = NetworkMock(json: fakeShip1)
-        wsDependencies.register(WebService.StarshipWS.tag, instance: mock as NetworkLayer)
+        wsDependencies.register(tag: WebService.StarshipWS.tag, instance: mock as NetworkLayer)
         
         let provider = SWAPIStarshipProvider()
         provider.fetch(1) { starship in
@@ -57,7 +57,7 @@ class SWAPIStarshipProviderTests: XCTestCase {
     func testFetchInvalidStarship() {
         let json = ["error":"whoops"]
         let mock = NetworkMock(json: json)
-        wsDependencies.register(WebService.StarshipWS.tag, instance: mock as NetworkLayer)
+        wsDependencies.register(tag: WebService.StarshipWS.tag, instance: mock as NetworkLayer)
         
         let provider = SWAPIStarshipProvider()
         provider.fetch(12) { starship in

--- a/README.md
+++ b/README.md
@@ -108,34 +108,28 @@ You can register factories that accept up to six arguments. When you resolve dep
 
 ```swift
 let webServices = DependencyContainer() { webServices in
-	webServices.register { (url: NSURL, port: Int) in WebService(name: "1", baseURL: url, port: port) as WebServiceAPI }
-   webServices.register { (port: Int, url: NSURL) in WebService(name: "2", baseURL: url, port: port) as WebServiceAPI }
-   webServices.register { (port: Int, url: NSURL?) in WebService(name: "3", baseURL: url!, port: port) as WebServiceAPI }
+	webServices.register { (url: NSURL, port: Int) in WebServiceImp1(url, port: port) as WebServiceAPI }
+	webServices.register { (port: Int, url: NSURL) in WebServiceImp2(url, port: port) as WebServiceAPI }
+	webServices.register { (port: Int, url: NSURL?) in WebServiceImp3(url!, port: port) as WebServiceAPI }
 }
 
-let service1 = webServices.resolve(NSURL(string: "http://example.url")!, 80) as WebServiceAPI // service1.name == "1"
-let service2 = webServices.resolve(80, NSURL(string: "http://example.url")!) as WebServiceAPI // service1.name == "2"
-let service3 = webServices.resolve(80, NSURL(string: "http://example.url")?) as WebServiceAPI // service1.name == "3"
+let service1 = webServices.resolve(NSURL(string: "http://example.url")!, 80) as WebServiceAPI // service1 is WebServiceImp1
+let service2 = webServices.resolve(80, NSURL(string: "http://example.url")!) as WebServiceAPI // service2 is WebServiceImp2
+let service3 = webServices.resolve(80, NSURL(string: "http://example.url")) as WebServiceAPI // service3 is WebServiceImp3
 
 ```
+Though Dip provides support for up to six runtime arguments out of the box you can extend this number using following code snippet for seven arguments:
 
-### Runtime arguments
-
-You can register factories that accept up to six arguments. When you resolve dependency you can pass those arguments to `resolve()` method and they will be passed to the factory. Note that _number_, _types_ and _order_ of parameters matters. Also use of optional parameter and not optional parameter will result in two factories registered in container.
-
-```swift
-let webServices = DependencyContainer() { webServices in
-	webServices.register { (url: NSURL, port: Int) in WebService(name: "1", baseURL: url, port: port) as WebServiceAPI }
-   webServices.register { (port: Int, url: NSURL) in WebService(name: "2", baseURL: url, port: port) as WebServiceAPI }
-   webServices.register { (port: Int, url: NSURL?) in WebService(name: "3", baseURL: url!, port: port) as WebServiceAPI }
+```
+func register<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(tag: Tag? = nil, factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> T) -> DefinitionOf<T> {
+	return register(tag, factory: factory, scope: .Prototype) as DefinitionOf<T>
+}
+	
+func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6, _ arg7: Arg7) -> T {
+	return resolve(tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) -> T) in factory(arg1, arg2, arg3, arg4, arg5, arg6, arg7) }
 }
 
-let service1 = webServices.resolve(NSURL(string: "http://example.url")!, 80) as WebServiceAPI // service1.name == "1"
-let service2 = webServices.resolve(80, NSURL(string: "http://example.url")!) as WebServiceAPI // service1.name == "2"
-let service3 = webServices.resolve(80, NSURL(string: "http://example.url")) as WebServiceAPI // service1.name == "3"
-
 ```
-
 
 ### Concrete Example
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,23 @@ let service3 = webServices.resolve(80, NSURL(string: "http://example.url")?) as 
 
 ```
 
+### Runtime arguments
+
+You can register factories that accept up to six arguments. When you resolve dependency you can pass those arguments to `resolve()` method and they will be passed to the factory. Note that _number_, _types_ and _order_ of parameters matters. Also use of optional parameter and not optional parameter will result in two factories registered in container.
+
+```swift
+let webServices = DependencyContainer() { webServices in
+	webServices.register { (url: NSURL, port: Int) in WebService(name: "1", baseURL: url, port: port) as WebServiceAPI }
+   webServices.register { (port: Int, url: NSURL) in WebService(name: "2", baseURL: url, port: port) as WebServiceAPI }
+   webServices.register { (port: Int, url: NSURL?) in WebService(name: "3", baseURL: url!, port: port) as WebServiceAPI }
+}
+
+let service1 = webServices.resolve(NSURL(string: "http://example.url")!, 80) as WebServiceAPI // service1.name == "1"
+let service2 = webServices.resolve(80, NSURL(string: "http://example.url")!) as WebServiceAPI // service1.name == "2"
+let service3 = webServices.resolve(80, NSURL(string: "http://example.url")) as WebServiceAPI // service1.name == "3"
+
+```
+
 
 ### Concrete Example
 


### PR DESCRIPTION
To register factories/instances it's now possible to use up to six runtime arguments. Clients can extend this number on demand.

@AliSoftware Please review it again. There are few changes that I want to note:

- I decided to remove method that registers factory that accepts tag as parameter, cause this case is covered with runtime arguments. Though I'm sure tags should stay, but they should be not used inside factories.

- Adding methods with generic arguments introduces ambiguity with `resolve` method that accepts only tag parameter, so I had to make `tag` parameter named.