### PR TITLE
Added documentation note on definition generic parameters

### DIFF
--- a/Dip/Dip/Definition.swift
+++ b/Dip/Dip/Definition.swift
@@ -56,7 +56,12 @@ public enum ComponentScope {
   case Singleton
 }
 
-///Definition of type T describes how instances of this type should be created when they are resolved by container.
+/**
+ Definition of type T describes how instances of this type should be created when this type is resolved by container.
+ Generic parameter `T` is the type of the instance to resolve, `F` is the type of block-factory that creates an instance of T.
+ 
+ For example `DefinitionOf<Service,(String)->Service>` is the type of definition that during resolution will produce instance of type `Service` using closure that accepts `String` argument.
+*/
 public struct DefinitionOf<T, F>: Definition {
   
   /**


### PR DESCRIPTION
Look's like develop is a protected brunch now so everything should go through PRs, or is there another way?