### PR TITLE
Add thread safety

### DIFF
--- a/Dip/Dip.xcodeproj/project.pbxproj
+++ b/Dip/Dip.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 		0919F4EC1C16419500DC3B10 /* DefinitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0919F4CF1C16417000DC3B10 /* DefinitionTests.swift */; };
 		0919F4ED1C16419500DC3B10 /* RuntimeArgumentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0919F4D21C16417000DC3B10 /* RuntimeArgumentsTests.swift */; };
 		0919F4EE1C16419500DC3B10 /* ComponentScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0919F4CE1C16417000DC3B10 /* ComponentScopeTests.swift */; };
+		2C15B9511C25F01200EA3486 /* ThreadSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C15B94F1C25EF7800EA3486 /* ThreadSafetyTests.swift */; };
+		2C15B9521C25F01300EA3486 /* ThreadSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C15B94F1C25EF7800EA3486 /* ThreadSafetyTests.swift */; };
+		2C15B9531C25F01500EA3486 /* ThreadSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C15B94F1C25EF7800EA3486 /* ThreadSafetyTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,6 +85,7 @@
 		0919F4D01C16417000DC3B10 /* DipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DipTests.swift; sourceTree = "<group>"; };
 		0919F4D11C16417000DC3B10 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0919F4D21C16417000DC3B10 /* RuntimeArgumentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeArgumentsTests.swift; sourceTree = "<group>"; };
+		2C15B94F1C25EF7800EA3486 /* ThreadSafetyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadSafetyTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -160,6 +164,7 @@
 				0919F4D21C16417000DC3B10 /* RuntimeArgumentsTests.swift */,
 				0919F4CE1C16417000DC3B10 /* ComponentScopeTests.swift */,
 				0919F4D11C16417000DC3B10 /* Info.plist */,
+				2C15B94F1C25EF7800EA3486 /* ThreadSafetyTests.swift */,
 			);
 			path = DipTests;
 			sourceTree = "<group>";
@@ -477,6 +482,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0919F4E61C16419300DC3B10 /* ComponentScopeTests.swift in Sources */,
+				2C15B9511C25F01200EA3486 /* ThreadSafetyTests.swift in Sources */,
 				0919F4E41C16419300DC3B10 /* DefinitionTests.swift in Sources */,
 				0919F4E31C16419300DC3B10 /* DipTests.swift in Sources */,
 				0919F4E51C16419300DC3B10 /* RuntimeArgumentsTests.swift in Sources */,
@@ -498,6 +504,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0919F4EA1C16419400DC3B10 /* ComponentScopeTests.swift in Sources */,
+				2C15B9521C25F01300EA3486 /* ThreadSafetyTests.swift in Sources */,
 				0919F4E81C16419400DC3B10 /* DefinitionTests.swift in Sources */,
 				0919F4E71C16419400DC3B10 /* DipTests.swift in Sources */,
 				0919F4E91C16419400DC3B10 /* RuntimeArgumentsTests.swift in Sources */,
@@ -519,6 +526,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0919F4EE1C16419500DC3B10 /* ComponentScopeTests.swift in Sources */,
+				2C15B9531C25F01500EA3486 /* ThreadSafetyTests.swift in Sources */,
 				0919F4EC1C16419500DC3B10 /* DefinitionTests.swift in Sources */,
 				0919F4EB1C16419500DC3B10 /* DipTests.swift in Sources */,
 				0919F4ED1C16419500DC3B10 /* RuntimeArgumentsTests.swift in Sources */,

--- a/Dip/DipTests/ComponentScopeTests.swift
+++ b/Dip/DipTests/ComponentScopeTests.swift
@@ -25,6 +25,20 @@
 import XCTest
 @testable import Dip
 
+class Server {
+  weak var client: Client?
+  
+  init() {}
+}
+
+class Client {
+  var server: Server
+  
+  init(server: Server) {
+    self.server = server
+  }
+}
+
 class ComponentScopeTests: XCTestCase {
   
   let container = DependencyContainer()
@@ -74,20 +88,6 @@ class ComponentScopeTests: XCTestCase {
     XCTAssertTrue((service1 as! ServiceImp1) === (service2 as! ServiceImp1))
   }
   
-  class Server {
-    weak var client: Client?
-    
-    init() {}
-  }
-  
-  class Client {
-    var server: Server
-    
-    init(server: Server) {
-      self.server = server
-    }
-  }
-
   func testThatItReusesInstanceInObjectGraphScopeDuringResolve() {
     //given
     container.register(.ObjectGraph) { Client(server: try! self.container.resolve()) as Client }

--- a/Dip/DipTests/DipTests.swift
+++ b/Dip/DipTests/DipTests.swift
@@ -35,9 +35,22 @@ extension Service {
   }
 }
 
-class ServiceImp1: Service {}
+internal func ==(lhs: HashableService, rhs: HashableService) -> Bool {
+  return lhs === rhs
+}
 
-class ServiceImp2: Service {}
+class HashableService : Service, Hashable {
+  internal var hashValue: Int { get {
+      return unsafeAddressOf(self).hashValue
+    }
+  }
+}
+
+class ServiceImp1: HashableService {
+}
+
+class ServiceImp2: HashableService {
+}
 
 class DipTests: XCTestCase {
   

--- a/Dip/DipTests/ThreadSafetyTests.swift
+++ b/Dip/DipTests/ThreadSafetyTests.swift
@@ -1,0 +1,150 @@
+//
+// Dip
+//
+// Copyright (c) 2015 Olivier Halligon <olivier@halligon.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import XCTest
+@testable import Dip
+
+class ThreadSafetyTests: XCTestCase {
+  
+  let container = DependencyContainer()
+  
+  override func setUp() {
+    super.setUp()
+    container.reset()
+  }
+  
+  func testSingletonThreadSafety() {
+    
+    container.register(.Singleton) { ServiceImp1() as Service }
+    
+    let queue = NSOperationQueue()
+    let lock = NSRecursiveLock()
+    var resultSet = Set<ServiceImp1>()
+    
+    for _ in 1...100 {
+      queue.addOperationWithBlock {
+        let serviceInstance = try! self.container.resolve() as Service
+        
+        lock.lock()
+        resultSet.insert(serviceInstance as! ServiceImp1)
+        lock.unlock()
+      }
+    }
+    
+    queue.waitUntilAllOperationsAreFinished()
+    
+    XCTAssertEqual(resultSet.count, 1)
+  }
+
+  func testFactoryThreadSafety() {
+    
+    container.register() { ServiceImp1() as Service }
+    
+    let queue = NSOperationQueue()
+    let lock = NSRecursiveLock()
+    var resultSet = Set<ServiceImp1>()
+    
+    for _ in 1...100 {
+      queue.addOperationWithBlock {
+        let serviceInstance = try! self.container.resolve() as Service
+        
+        lock.lock()
+        resultSet.insert(serviceInstance as! ServiceImp1)
+        lock.unlock()
+      }
+    }
+    
+    queue.waitUntilAllOperationsAreFinished()
+    
+    XCTAssertEqual(resultSet.count, 100)
+  }
+  
+  func testCircularReferenceThreadSafety() {
+    //given
+    container.register(.ObjectGraph) { Client(server: try! self.container.resolve()) as Client }
+    
+    container.register(.ObjectGraph) { Server() as Server }.resolveDependencies { container, server in
+      server.client = try! container.resolve() as Client
+    }
+
+    let queue = NSOperationQueue()
+
+    for _ in 1...100 {
+      queue.addOperationWithBlock {
+        //when
+        let client = try! self.container.resolve() as Client
+
+        //then
+        let server = client.server
+        XCTAssertTrue(server.client === client)
+      }
+    }
+
+    queue.waitUntilAllOperationsAreFinished()
+  }
+  
+  func testThreadSafetyPerformance() {
+    container.register() { ServiceImp1() as Service }
+
+    measureBlock() {
+      for _ in 1...10000 {
+        let _ = try! self.container.resolve() as Service
+      }
+    }
+  }
+  
+  func testNoThreadSafetyPerformance() {
+    let unsafeContainer = DependencyContainer(isThreadSafe:false)
+    unsafeContainer.register() { ServiceImp1() as Service }
+    
+    measureBlock() {
+      for _ in 1...10000 {
+        let _ = try! unsafeContainer.resolve() as Service
+      }
+    }
+  }
+  
+  func testNSRecursiveLockPerformance() {
+    
+    let lock = NSRecursiveLock()
+    
+    measureBlock() {
+      for _ in 1...1000000 {
+        lock.lock()
+        lock.unlock()
+      }
+    }
+  }
+  
+  func testObjcSyncEnterExitPerformance() {
+    
+    measureBlock() {
+      for _ in 1...1000000 {
+        objc_sync_enter(self)
+        objc_sync_exit(self)
+      }
+    }
+    
+  }
+}


### PR DESCRIPTION
Add locking around resolution and dictionary modification to ensure thread safety

My understanding is Dip isn't currently thread safe when resolving, with risk of two instances of singleton being returned if same type requested at same time from different threads. How about this change to address this? I'd ideally want any container I used to be thread safe :-)

Let me know what you think !

Kind regards
Mark