### PR TITLE
Throwing factories and resolve dependencies block

### DIFF
--- a/Dip/Dip/Definition.swift
+++ b/Dip/Dip/Definition.swift
@@ -81,12 +81,12 @@ public final class DefinitionOf<T, F>: Definition {
 
    var definition = container.register { ServiceImp() as Service }
    definition.resolveDependencies { container, service in
-      service.delegate = container.resolve() as Client
+      service.delegate = try container.resolve() as Client
    }
    ```
    
    */
-  public func resolveDependencies(block: (DependencyContainer, T) -> ()) -> DefinitionOf<T, F> {
+  public func resolveDependencies(block: (DependencyContainer, T) throws -> ()) -> DefinitionOf<T, F> {
     guard resolveDependenciesBlock == nil else {
       fatalError("You can not change resolveDependencies block after it was set.")
     }
@@ -96,7 +96,7 @@ public final class DefinitionOf<T, F>: Definition {
   
   let factory: F
   var scope: ComponentScope
-  var resolveDependenciesBlock: ((DependencyContainer, T) -> ())?
+  var resolveDependenciesBlock: ((DependencyContainer, T) throws -> ())?
   
   init(factory: F, scope: ComponentScope) {
     self.factory = factory

--- a/Dip/Dip/Dip.swift
+++ b/Dip/Dip/Dip.swift
@@ -201,7 +201,7 @@ public final class DependencyContainer {
   }
   
   /// Actually resolve dependency
-  private func _resolve<T, F>(tag: Tag? = nil, key: DefinitionKey?, definition: DefinitionOf<T, F>, builder: F throws -> T) throws -> T {
+  private func _resolve<T, F>(tag: Tag? = nil, key: DefinitionKey?, definition: DefinitionOf<T, F>, builder: F throws -> T) rethrows -> T {
     
     return try resolvedInstances.resolve {
       

--- a/Dip/Dip/RuntimeArguments.swift
+++ b/Dip/Dip/RuntimeArguments.swift
@@ -41,8 +41,8 @@ extension DependencyContainer {
   
   - seealso: `registerFactory(tag:scope:factory:)`
   */
-  public func register<T, Arg1>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1) -> T) -> DefinitionOf<T, (Arg1) -> T> {
-    return registerFactory(tag: tag, scope: scope, factory: factory) as DefinitionOf<T, (Arg1) -> T>
+  public func register<T, Arg1>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1) throws -> T) -> DefinitionOf<T, (Arg1) throws -> T> {
+    return registerFactory(tag: tag, scope: scope, factory: factory)
   }
   
   /**
@@ -55,63 +55,63 @@ extension DependencyContainer {
    - seealso: `resolve(tag:builder:)`
    */
   public func resolve<T, Arg1>(tag tag: Tag? = nil, withArguments arg1: Arg1) throws -> T {
-    return try resolve(tag: tag) { (factory: (Arg1) -> T) in factory(arg1) }
+    return try resolve(tag: tag) { (factory: (Arg1) throws -> T) in try factory(arg1) }
   }
   
   // MARK: 2 Runtime Arguments
   
   /// - seealso: `register(:factory:scope:)`
-  public func register<T, Arg1, Arg2>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2) -> T) -> DefinitionOf<T, (Arg1, Arg2) -> T> {
-    return registerFactory(tag: tag, scope: scope, factory: factory) as DefinitionOf<T, (Arg1, Arg2) -> T>
+  public func register<T, Arg1, Arg2>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2) throws -> T) -> DefinitionOf<T, (Arg1, Arg2) throws -> T> {
+    return registerFactory(tag: tag, scope: scope, factory: factory)
   }
   
   /// - seealso: `resolve(tag:_:)`
   public func resolve<T, Arg1, Arg2>(tag tag: Tag? = nil, withArguments arg1: Arg1, _ arg2: Arg2) throws -> T {
-    return try resolve(tag: tag) { (factory: (Arg1, Arg2) -> T) in factory(arg1, arg2) }
+    return try resolve(tag: tag) { (factory: (Arg1, Arg2) throws -> T) in try factory(arg1, arg2) }
   }
 
   // MARK: 3 Runtime Arguments
   
-  public func register<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3) -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3) -> T> {
-    return registerFactory(tag: tag, scope: scope, factory: factory) as DefinitionOf<T, (Arg1, Arg2, Arg3) -> T>
+  public func register<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3) throws -> T> {
+    return registerFactory(tag: tag, scope: scope, factory: factory)
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
   public func resolve<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, withArguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) throws -> T {
-    return try resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3) -> T) in factory(arg1, arg2, arg3) }
+    return try resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3) throws -> T) in try factory(arg1, arg2, arg3) }
   }
   
   // MARK: 4 Runtime Arguments
   
-  public func register<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4) -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4) -> T> {
-    return registerFactory(tag: tag, scope: scope, factory: factory) as DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4) -> T>
+  public func register<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4) throws -> T> {
+    return registerFactory(tag: tag, scope: scope, factory: factory)
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
   public func resolve<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, withArguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) throws -> T {
-    return try resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4) -> T) in factory(arg1, arg2, arg3, arg4) }
+    return try resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4) throws -> T) in try factory(arg1, arg2, arg3, arg4) }
   }
 
   // MARK: 5 Runtime Arguments
   
-  public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4, Arg5) -> T> {
-    return registerFactory(tag: tag, scope: scope, factory: factory) as DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4, Arg5) -> T>
+  public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4, Arg5) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4, Arg5) throws -> T> {
+    return registerFactory(tag: tag, scope: scope, factory: factory)
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
   public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, withArguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) throws -> T {
-    return try resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5) -> T) in factory(arg1, arg2, arg3, arg4, arg5) }
+    return try resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5) throws -> T) in try factory(arg1, arg2, arg3, arg4, arg5) }
   }
 
   // MARK: 6 Runtime Arguments
   
-  public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T> {
-    return registerFactory(tag: tag, scope: scope, factory: factory) as DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T>
+  public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) throws -> T> {
+    return registerFactory(tag: tag, scope: scope, factory: factory)
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
   public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: Tag? = nil, withArguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) throws -> T {
-    return try resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) -> T) in factory(arg1, arg2, arg3, arg4, arg5, arg6) }
+    return try resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) throws -> T) in try factory(arg1, arg2, arg3, arg4, arg5, arg6) }
   }
 
 }

--- a/Dip/DipTests/ComponentScopeTests.swift
+++ b/Dip/DipTests/ComponentScopeTests.swift
@@ -90,10 +90,10 @@ class ComponentScopeTests: XCTestCase {
 
   func testThatItReusesInstanceInObjectGraphScopeDuringResolve() {
     //given
-    container.register(.ObjectGraph) { Client(server: try! self.container.resolve()) as Client }
+    container.register(.ObjectGraph) { Client(server: try self.container.resolve()) as Client }
     
     container.register(.ObjectGraph) { Server() as Server }.resolveDependencies { container, server in
-      server.client = try! container.resolve() as Client
+      server.client = try container.resolve() as Client
     }
     
     //when
@@ -106,9 +106,9 @@ class ComponentScopeTests: XCTestCase {
   
   func testThatItDoesNotReuseInstanceInObjectGraphScopeInNextResolve() {
     //given
-    container.register(.ObjectGraph) { Client(server: try! self.container.resolve()) as Client }
+    container.register(.ObjectGraph) { Client(server: try self.container.resolve()) as Client }
     container.register(.ObjectGraph) { Server() as Server }.resolveDependencies { container, server in
-      server.client = try! container.resolve() as Client
+      server.client = try container.resolve() as Client
     }
     
     //when
@@ -127,7 +127,7 @@ class ComponentScopeTests: XCTestCase {
     //given
     var service2: Service?
     container.register(.ObjectGraph) { ServiceImp1() as Service }.resolveDependencies { (c, _) in
-      service2 = try! c.resolve(tag: "service") as Service
+      service2 = try c.resolve(tag: "service") as Service
     }
     container.register(tag: "service", .ObjectGraph) { ServiceImp2() as Service}
     

--- a/Dip/DipTests/DipTests.swift
+++ b/Dip/DipTests/DipTests.swift
@@ -122,7 +122,7 @@ class DipTests: XCTestCase {
       XCTFail("Unexpectedly resolved protocol")
     }
     catch DipError.DefinitionNotFound(let key) {
-      typealias F = ()->Service
+      typealias F = () throws -> Service
       let expectedKey = DefinitionKey(protocolType: Service.self, factoryType: F.self, associatedTag: nil)
       XCTAssertEqual(key, expectedKey)
     }
@@ -141,7 +141,7 @@ class DipTests: XCTestCase {
       XCTFail("Unexpectedly resolved protocol")
     }
     catch DipError.DefinitionNotFound(let key) {
-      typealias F = ()->Service
+      typealias F = () throws -> Service
       let expectedKey = DefinitionKey(protocolType: Service.self, factoryType: F.self, associatedTag: "other tag")
       XCTAssertEqual(key, expectedKey)
     }
@@ -160,7 +160,7 @@ class DipTests: XCTestCase {
       XCTFail("Unexpectedly resolved protocol")
     }
     catch DipError.DefinitionNotFound(let key) {
-      typealias F = (String)->Service
+      typealias F = (String) throws -> Service
       let expectedKey = DefinitionKey(protocolType: Service.self, factoryType: F.self, associatedTag: nil)
       XCTAssertEqual(key, expectedKey)
     }

--- a/DipPlayground.playground/Pages/Circular dependencies.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Circular dependencies.xcplaygroundpage/Contents.swift
@@ -44,12 +44,12 @@ Now you can register those classes in container:
 */
 
 container.register(.ObjectGraph) {
-    Interactor(networkClient: try! container.resolve()) as NetworkClientDelegate
+    Interactor(networkClient: try container.resolve()) as NetworkClientDelegate
 }
 
 container.register(.ObjectGraph) { NetworkClientImp() as NetworkClient }
     .resolveDependencies { (container, client) -> () in
-        client.delegate = try! container.resolve() as NetworkClientDelegate
+        client.delegate = try container.resolve() as NetworkClientDelegate
 }
 
 /*:
@@ -92,12 +92,12 @@ If we would have used `.Prototype` for one of the components it will lead to the
 container.reset()
 
 container.register(.Prototype) {
-    Interactor(networkClient: try! container.resolve()) as NetworkClientDelegate
+    Interactor(networkClient: try container.resolve()) as NetworkClientDelegate
 }
 
 container.register(.ObjectGraph) { NetworkClientImp() as NetworkClient }
     .resolveDependencies { (container, client) -> () in
-        client.delegate = try! container.resolve() as NetworkClientDelegate
+        client.delegate = try container.resolve() as NetworkClientDelegate
 }
 
 let invalidInteractor = try! container.resolve() as NetworkClientDelegate

--- a/DipPlayground.playground/contents.xcplayground
+++ b/DipPlayground.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='ios' display-mode='raw'>
+<playground version='6.0' target-platform='ios' display-mode='rendered'>
     <pages>
         <page name='What is Dip?'/>
         <page name='Creating container'/>

--- a/README.md
+++ b/README.md
@@ -168,12 +168,12 @@ _Dip_ supports circular dependencies. To resolve them use `ObjectGraph` scope an
 
 ```swift
 container.register(.ObjectGraph) {
-    ClientImp(server: try! container.resolve() as Server) as Client 
+    ClientImp(server: try container.resolve() as Server) as Client 
 }
 
 container.register(.ObjectGraph) { ServerImp() as Server }
     .resolveDependencies { container, server in 
-        server.client = try! container.resolve() as Client
+        server.client = try container.resolve() as Client
     }
 ```
 More infromation about circular dependencies you can find in a playground.


### PR DESCRIPTION
With that PR we no more need to call `container.resolve()` with `try!` inside a factory or `resolveDependencies` block. Also convenient to use throwing constructors or any other throwing methods inside those blocks. Error will be catched by container, printed in console and then will be re-thrown.

Note: There is no way (at least for now) I can think of to be able to distinguish between throwing and not-throwing factories (thus the latest definition will override previous), except of duplicating all `register`/`resolve` methods, what I don't like at all cause it will double the number of methods in container. Taking in account that tag is an optional argument and we have support for 6 runtime arguments already (and upcoming multi-injection feature will ad 6 more methods) it will make API too much bloated.