### PR TITLE
Auto-injection improvements

### DIFF
--- a/Dip/Dip.xcodeproj/project.pbxproj
+++ b/Dip/Dip.xcodeproj/project.pbxproj
@@ -38,6 +38,10 @@
 		0919F4EC1C16419500DC3B10 /* DefinitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0919F4CF1C16417000DC3B10 /* DefinitionTests.swift */; };
 		0919F4ED1C16419500DC3B10 /* RuntimeArgumentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0919F4D21C16417000DC3B10 /* RuntimeArgumentsTests.swift */; };
 		0919F4EE1C16419500DC3B10 /* ComponentScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0919F4CE1C16417000DC3B10 /* ComponentScopeTests.swift */; };
+		0982AF0C1C5183A000B62463 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0982AF0B1C5183A000B62463 /* Utils.swift */; };
+		0982AF0D1C5183A000B62463 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0982AF0B1C5183A000B62463 /* Utils.swift */; };
+		0982AF0E1C5183A000B62463 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0982AF0B1C5183A000B62463 /* Utils.swift */; };
+		0982AF0F1C5183A000B62463 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0982AF0B1C5183A000B62463 /* Utils.swift */; };
 		09873F561C1E0237000C02F6 /* AutoInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09873F551C1E0237000C02F6 /* AutoInjection.swift */; };
 		09873F771C1E024E000C02F6 /* AutoInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09873F751C1E0249000C02F6 /* AutoInjectionTests.swift */; };
 		09873F781C1E024E000C02F6 /* AutoInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09873F751C1E0249000C02F6 /* AutoInjectionTests.swift */; };
@@ -92,6 +96,7 @@
 		0919F4D01C16417000DC3B10 /* DipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DipTests.swift; sourceTree = "<group>"; };
 		0919F4D11C16417000DC3B10 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0919F4D21C16417000DC3B10 /* RuntimeArgumentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeArgumentsTests.swift; sourceTree = "<group>"; };
+		0982AF0B1C5183A000B62463 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		09873F551C1E0237000C02F6 /* AutoInjection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoInjection.swift; sourceTree = "<group>"; };
 		09873F751C1E0249000C02F6 /* AutoInjectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoInjectionTests.swift; sourceTree = "<group>"; };
 		2C15B94F1C25EF7800EA3486 /* ThreadSafetyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadSafetyTests.swift; sourceTree = "<group>"; };
@@ -161,6 +166,7 @@
 				0919F4C81C16417000DC3B10 /* Definition.swift */,
 				0919F4CC1C16417000DC3B10 /* RuntimeArguments.swift */,
 				09873F551C1E0237000C02F6 /* AutoInjection.swift */,
+				0982AF0B1C5183A000B62463 /* Utils.swift */,
 				0919F4CB1C16417000DC3B10 /* Info.plist */,
 			);
 			path = Dip;
@@ -482,6 +488,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0982AF0C1C5183A000B62463 /* Utils.swift in Sources */,
 				0919F4D51C16417B00DC3B10 /* Definition.swift in Sources */,
 				0919F4D41C16417B00DC3B10 /* Dip.swift in Sources */,
 				09873F561C1E0237000C02F6 /* AutoInjection.swift in Sources */,
@@ -506,6 +513,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0982AF0D1C5183A000B62463 /* Utils.swift in Sources */,
 				0919F4D91C16417C00DC3B10 /* Definition.swift in Sources */,
 				0919F4D81C16417C00DC3B10 /* Dip.swift in Sources */,
 				09873F7A1C1E0252000C02F6 /* AutoInjection.swift in Sources */,
@@ -530,6 +538,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0982AF0E1C5183A000B62463 /* Utils.swift in Sources */,
 				0919F4DD1C16417D00DC3B10 /* Definition.swift in Sources */,
 				0919F4DC1C16417D00DC3B10 /* Dip.swift in Sources */,
 				09873F7B1C1E0253000C02F6 /* AutoInjection.swift in Sources */,
@@ -554,6 +563,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0982AF0F1C5183A000B62463 /* Utils.swift in Sources */,
 				0919F4E11C16417E00DC3B10 /* Definition.swift in Sources */,
 				0919F4E01C16417E00DC3B10 /* Dip.swift in Sources */,
 				09873F7C1C1E0254000C02F6 /* AutoInjection.swift in Sources */,

--- a/Dip/Dip.xcodeproj/xcshareddata/xcschemes/Dip-iOS.xcscheme
+++ b/Dip/Dip.xcodeproj/xcshareddata/xcschemes/Dip-iOS.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Dip/Dip/AutoInjection.swift
+++ b/Dip/Dip/AutoInjection.swift
@@ -46,18 +46,23 @@ class ClientImp: Client {
 */
 public final class Injected<T>: _InjectedPropertyBox {
   
-  var _value: Any?
-  
-  public var value: T? {
-    get {
-      return _value as? T
-    }
-    set {
-      _value = newValue
+  var _value: Any? = nil {
+    didSet {
+      if let value = value {
+        didInject(value)
+      }
     }
   }
+  
+  private let didInject: T -> ()
+  
+  public var value: T? {
+    return _value as? T
+  }
 
-  public init() {}
+  public init(didInject: T -> () = { _ in }) {
+    self.didInject = didInject
+  }
 
 }
 
@@ -100,18 +105,23 @@ public final class InjectedWeak<T>: _InjectedWeakPropertyBox {
   //so we just rely on user reading documentation and passing AnyObject in runtime
   //also we will throw fatal error if type can not be casted to AnyObject during resolution
 
-  weak var _value: AnyObject?
-  
-  public var value: T? {
-    get {
-      return _value as? T
-    }
-    set {
-      _value = newValue as? AnyObject
+  weak var _value: AnyObject? = nil {
+    didSet {
+      if let value = value {
+        didInject(value)
+      }
     }
   }
+  
+  private var didInject: T -> ()
+  
+  public var value: T? {
+    return _value as? T
+  }
 
-  public init() {}
+  public init(didInject: T -> () = { _ in }) {
+    self.didInject = didInject
+  }
 
 }
 

--- a/Dip/Dip/AutoInjection.swift
+++ b/Dip/Dip/AutoInjection.swift
@@ -169,29 +169,6 @@ extension DependencyContainer {
 typealias InjectedFactory = () throws -> Any
 typealias InjectedWeakFactory = () throws -> AnyObject
 
-extension DependencyContainer {
-  
-  func registerInjected(definition: AutoInjectedDefinition) {
-    if let key = definition.injectedKey, definition = definition.injectedDefinition {
-        definitions[key] = definition
-    }
-  }
-  
-  func registerInjectedWeak(definition: AutoInjectedDefinition) {
-    if let key = definition.injectedWeakKey, definition = definition.injectedWeakDefinition {
-        definitions[key] = definition
-    }
-  }
-  
-  func removeInjected(definition: AutoInjectedDefinition) {
-    definitions[definition.injectedKey] = nil
-  }
-  
-  func removeInjectedWeak(definition: AutoInjectedDefinition) {
-    definitions[definition.injectedWeakKey] = nil
-  }
-
-}
 
 protocol _AnyInjectedPropertyBox: class {
   func resolve(container: DependencyContainer) throws
@@ -228,31 +205,11 @@ extension _InjectedWeakPropertyBox {
   }
 }
 
-func isInjectedTag(tag: DependencyContainer.Tag?) -> String? {
+func autoInjectedType(tag: DependencyContainer.Tag?) -> String? {
   guard let tag = tag else { return nil }
   guard case let .String(stringTag) = tag else { return nil }
   
   return try! stringTag.match("^Injected(?:Weak)?<(.+)>$")?.dropFirst().first
 }
 
-extension String {
-  func match(pattern: String) throws -> [String]? {
-    let expr = try NSRegularExpression(pattern: pattern, options: NSRegularExpressionOptions())
-    let result = expr.firstMatchInString(self, options: NSMatchingOptions(), range: NSMakeRange(0, characters.count))
-    return result?.allRanges.flatMap(safeSubstringWithRange)
-  }
-  
-  func safeSubstringWithRange(range: NSRange) -> String? {
-    if NSMaxRange(range) <= self.characters.count {
-      return (self as NSString).substringWithRange(range)
-    }
-    return nil
-  }
-}
-
-extension NSTextCheckingResult {
-  var allRanges: [NSRange] {
-    return (0..<numberOfRanges).map(rangeAtIndex)
-  }
-}
 

--- a/Dip/Dip/AutoInjection.swift
+++ b/Dip/Dip/AutoInjection.swift
@@ -109,8 +109,8 @@ public final class Injected<T>: _InjectedPropertyBox<T>, _AnyInjectedPropertyBox
     return _value as? T
   }
 
-  public override init(required: Bool = true, didInject: T -> () = { _ in }) {
-    super.init(required: required, didInject: didInject)
+  public override init(required: Bool = true, tag: DependencyContainer.Tag? = nil, didInject: T -> () = { _ in }) {
+    super.init(required: required, tag: tag, didInject: didInject)
   }
   
   private func resolve(container: DependencyContainer) throws {
@@ -169,8 +169,8 @@ public final class InjectedWeak<T>: _InjectedPropertyBox<T>, _AnyInjectedPropert
     return _value as? T
   }
 
-  public override init(required: Bool = true, didInject: T -> () = { _ in }) {
-    super.init(required: required, didInject: didInject)
+  public override init(required: Bool = true, tag: DependencyContainer.Tag? = nil, didInject: T -> () = { _ in }) {
+    super.init(required: required, tag: tag, didInject: didInject)
   }
   
   private func resolve(container: DependencyContainer) throws {
@@ -191,19 +191,21 @@ private class _InjectedPropertyBox<T> {
 
   let required: Bool
   let didInject: T -> ()
+  let tag: DependencyContainer.Tag?
 
-  init(required: Bool = true, didInject: T -> () = { _ in }) {
+  init(required: Bool = true, tag: DependencyContainer.Tag?, didInject: T -> () = { _ in }) {
     self.required = required
+    self.tag = tag
     self.didInject = didInject
   }
 
   private func resolve(container: DependencyContainer) throws -> T? {
     let resolved: T?
     if required {
-      resolved = try container.resolve(builder: { (factory: () throws -> T) in try factory() }) as T
+      resolved = try container.resolve(tag: tag, builder: { (factory: () throws -> T) in try factory() }) as T
     }
     else {
-      resolved = try? container.resolve(builder: { (factory: () throws -> T) in try factory() }) as T
+      resolved = try? container.resolve(tag: tag, builder: { (factory: () throws -> T) in try factory() }) as T
     }
     return resolved
   }

--- a/Dip/Dip/AutoInjection.swift
+++ b/Dip/Dip/AutoInjection.swift
@@ -67,6 +67,15 @@ public final class Injected<T>: _InjectedPropertyBox {
  Otherwise it will cause runtime exception when container will try to resolve the property.
  Use this wrapper to define one of two circular dependencies to avoid retain cycle.
  
+ - note:
+ The only difference between `InjectedWeak` and `Injected` is that `InjectedWeak` uses _weak_ reference
+ to store underlying value, when `Injected` uses _strong_ reference. For that reason if you resolve instance
+ that has _weak_ auto-injected property this property will be released when `resolve` returns because no one else
+ holds reference to it except the container during dependency graph resolution.
+ 
+ Use `InjectedWeak<T>` to define one of two circular dependecies if another dependency is defined as `Injected<U>`.
+ This will prevent a retain cycle between resolved instances.
+
  - warning:
  Do not define this property as optional or container will not be able to inject it.
  Instead define it with initial value of `InjectedWeak<T>()`.
@@ -80,12 +89,6 @@ If you need to nilify wrapped value, assing property to `InjectedWeak<T>()`.
  }
 
  ```
- 
- - note:
- The only difference between `InjectedWeak` and `Injected` is that `InjectedWeak` uses _weak_ reference
- to store underlying value, when `Injected` uses _strong_ reference.
- For that reason if you resolve instance that holds weakly injected property
- this property will be released when `resolve` returns 'cause no one else holds reference to it.
  
  - seealso: `Injected`, `DependencyContainer.resolveDependencies(_:)`
  

--- a/Dip/Dip/AutoInjection.swift
+++ b/Dip/Dip/AutoInjection.swift
@@ -154,14 +154,12 @@ extension DependencyContainer {
    ```
    
    */
-  public func resolveDependencies(instance: Any) {
-    for child in Mirror(reflecting: instance).children {
-      do {
-        try (child.value as? _AnyInjectedPropertyBox)?.resolve(self)
-      } catch {
-        print(error)
-      }
-    }
+  public func resolveDependencies(instance: Any) throws {
+    try Mirror(reflecting: instance).children.forEach(resolveChild)
+  }
+  
+  private func resolveChild(child: Mirror.Child) throws {
+    try (child.value as? _AnyInjectedPropertyBox)?.resolve(self)
   }
 
 }
@@ -174,24 +172,22 @@ typealias InjectedWeakFactory = () throws -> AnyObject
 extension DependencyContainer {
   
   func registerInjected(definition: AutoInjectedDefinition) {
-    guard let key = definition.injectedKey,
-      definition = definition.injectedDefinition else { return }
-    definitions[key] = definition
+    if let key = definition.injectedKey, definition = definition.injectedDefinition {
+        definitions[key] = definition
+    }
   }
   
   func registerInjectedWeak(definition: AutoInjectedDefinition) {
-    guard let key = definition.injectedWeakKey,
-      definition = definition.injectedWeakDefinition else { return }
-    definitions[key] = definition
+    if let key = definition.injectedWeakKey, definition = definition.injectedWeakDefinition {
+        definitions[key] = definition
+    }
   }
   
   func removeInjected(definition: AutoInjectedDefinition) {
-    guard definition.injectedDefinition != nil else { return }
     definitions[definition.injectedKey] = nil
   }
   
   func removeInjectedWeak(definition: AutoInjectedDefinition) {
-    guard definition.injectedWeakDefinition != nil else { return }
     definitions[definition.injectedWeakKey] = nil
   }
 

--- a/Dip/Dip/AutoInjection.swift
+++ b/Dip/Dip/AutoInjection.swift
@@ -27,51 +27,6 @@
 extension DependencyContainer {
   
   /**
-   Resolves dependencies of passed in instance.
-   Use this method to resolve dependencies of object created not by container.
-   The type of the instance should be registered in the container.
-   
-   This method will do the same as `resolve(tag:)`, but instead of calling factory
-   will use passed in instance as resolved instance.
-   
-   - parameter instance: object which dependecies should be resolved
-   - parameter tag: optional tag used to register the type in container
-   
-   **Example**:
-   
-   ```swift
-   class ClientImp: Client {
-     var service: Service?
-   }
-   
-   class ServiceImp: Service {
-     weak var client: Client?
-   }
-   
-   container.register(.ObjectGraph) { ClientImp() as Client }
-     .resolveDependencies { container, client in
-       client.service = try container.resolve() as Service
-   }
-   
-   container.register(.ObjectGraph) { ServiceImp() as Service }
-     .resolveDependencies { container, service in
-       service.client = try container.resolve() as Client
-   }
-   
-   let client = ClientImp()
-   container.resolveDependencies(client as Client)
-   //client === service.client
-   
-   ```
-   
-   - seealso: `register(tag:_:factory:)`
-   
-   */
-  public func resolveDependenciesOf<T>(instance: T, forTag tag: Tag? = nil) throws {
-    try resolve(tag: tag) { (factory: () throws -> T) in instance }
-  }
-
-  /**
    Resolves properties of passed object wrapped with `Injected<T>` or `InjectedWeak<T>`
    */
   func autoInjectProperties(instance: Any) throws {

--- a/Dip/Dip/AutoInjection.swift
+++ b/Dip/Dip/AutoInjection.swift
@@ -53,8 +53,8 @@ private protocol _AnyInjectedPropertyBox: class {
 
 
 /**
- Use this wrapper to identifiy strong properties of the instance that should be injected when you call
- `resolveDependencies()` on this instance. Type T can be any type.
+ Use this wrapper to identifiy strong properties of the instance that should be
+ auto-injected by `DependencyContainer`. Type T can be any type.
 
  - warning: Do not define this property as optional or container will not be able to inject it.
             Instead define it with initial value of `Injected<T>()`.
@@ -67,7 +67,7 @@ private protocol _AnyInjectedPropertyBox: class {
  }
 
  ```
- - seealso: `InjectedWeak`, `DependencyContainer.resolveDependencies(_:)`
+ - seealso: `InjectedWeak`
 
 */
 public final class Injected<T>: _InjectedPropertyBox<T>, _AnyInjectedPropertyBox {
@@ -106,8 +106,8 @@ public final class Injected<T>: _InjectedPropertyBox<T>, _AnyInjectedPropertyBox
 }
 
 /**
- Use this wrapper to identify weak properties of the instance that should be injected when you call
- `resolveDependencies()` on this instance. Type T should be a **class** type.
+ Use this wrapper to identifiy strong properties of the instance that should be
+ auto-injected by `DependencyContainer`. Type T should be a **class** type.
  Otherwise it will cause runtime exception when container will try to resolve the property.
  Use this wrapper to define one of two circular dependencies to avoid retain cycle.
  
@@ -132,7 +132,7 @@ public final class Injected<T>: _InjectedPropertyBox<T>, _AnyInjectedPropertyBox
 
  ```
  
- - seealso: `Injected`, `DependencyContainer.resolveDependencies(_:)`
+ - seealso: `Injected`
  
  */
 public final class InjectedWeak<T>: _InjectedPropertyBox<T>, _AnyInjectedPropertyBox {

--- a/Dip/Dip/Definition.swift
+++ b/Dip/Dip/Definition.swift
@@ -23,7 +23,7 @@
 //
 
 ///Internal representation of a key used to associate definitons and factories by tag, type and factory.
-public struct DefinitionKey : Hashable, Equatable, CustomStringConvertible {
+public struct DefinitionKey : Hashable, CustomStringConvertible {
   public let protocolType: Any.Type
   public let factoryType: Any.Type
   public let associatedTag: DependencyContainer.Tag?
@@ -52,11 +52,18 @@ public func ==(lhs: DefinitionKey, rhs: DefinitionKey) -> Bool {
 
 ///Describes the lifecycle of instances created by container.
 public enum ComponentScope {
+  
   /// Indicates that a new instance of the component will be created each time it's resolved.
   case Prototype
-  /// Indicates that instances will be reused during resolve but will be discurded when topmost `resolve` method returns.
+  
+  /// Indicates that resolved instance should be reused during object graph resolution but
+  /// should be discurded when topmost `resolve` method returns.
+  /// Always use this scope do define circular dependencies.
   case ObjectGraph
-  /// Indicates that resolved component should be retained by container and always reused.
+  
+  /// Indicates that resolved instance should be retained and always reused.
+  /// Instance will be released as soon as definition is removed from all containers 
+  /// where it was registered or all these containers are deallocated.
   case Singleton
 }
 
@@ -102,6 +109,11 @@ public final class DefinitionOf<T, F>: Definition {
     return self
   }
   
+  func resolveDependencies(container: DependencyContainer, resolvedInstance: Any) throws {
+    guard let resolvedInstance = resolvedInstance as? T else { return }
+    try self.resolveDependenciesBlock?(container, resolvedInstance)
+  }
+  
   let factory: F
   private(set) var scope: ComponentScope = .Prototype
   
@@ -116,18 +128,20 @@ public final class DefinitionOf<T, F>: Definition {
     self.scope = scope
     
     if let factory = factory as? () throws -> T {
+      self.injectedKey = DefinitionKey(protocolType: Any.self, factoryType: InjectedFactory.self, associatedTag: Injected<T>.tag)
+      self.injectedWeakKey = DefinitionKey(protocolType: AnyObject.self, factoryType: InjectedWeakFactory.self, associatedTag: InjectedWeak<T>.tag)
+      
+      //these definitions will be used during auto-injection
       injectedDefinition = DefinitionOf<Any, InjectedFactory>(factory: { try factory() })
       injectedDefinition!.scope = scope
-      injectedKey = DefinitionKey(protocolType: Any.self, factoryType: InjectedFactory.self, associatedTag: Injected<T>.tag)
       
       injectedWeakDefinition = DefinitionOf<AnyObject, InjectedWeakFactory>(factory: {
         guard let result = try factory() as? AnyObject else {
           fatalError("\(T.self) can not be casted to AnyObject. InjectedWeak wrapper should be used to wrap only classes.")
         }
         return result
-        })
+      })
       injectedWeakDefinition!.scope = scope
-      injectedWeakKey = DefinitionKey(protocolType: AnyObject.self, factoryType: InjectedWeakFactory.self, associatedTag: InjectedWeak<T>.tag)
     }
   }
   
@@ -170,9 +184,13 @@ protocol AutoInjectedDefinition: Definition {
 
   var injectedWeakDefinition: DefinitionOf<AnyObject, InjectedWeakFactory>? { get }
   var injectedWeakKey: DefinitionKey? { get }
+
+  var scope: ComponentScope { get }
+
+  func resolveDependencies(container: DependencyContainer, resolvedInstance: Any) throws
 }
 
-extension DefinitionOf: AutoInjectedDefinition {}
+extension DefinitionOf: AutoInjectedDefinition { }
 
 extension DefinitionOf: CustomStringConvertible {
   public var description: String {

--- a/Dip/Dip/Definition.swift
+++ b/Dip/Dip/Definition.swift
@@ -128,12 +128,12 @@ public final class DefinitionOf<T, F>: Definition {
     self.scope = scope
     
     if let factory = factory as? () throws -> T {
-      self.injectedKey = DefinitionKey(protocolType: Any.self, factoryType: InjectedFactory.self, associatedTag: Injected<T>.tag)
-      self.injectedWeakKey = DefinitionKey(protocolType: AnyObject.self, factoryType: InjectedWeakFactory.self, associatedTag: InjectedWeak<T>.tag)
+      injectedKey = DefinitionKey(protocolType: Any.self, factoryType: InjectedFactory.self, associatedTag: Injected<T>.tag)
+      injectedWeakKey = DefinitionKey(protocolType: AnyObject.self, factoryType: InjectedWeakFactory.self, associatedTag: InjectedWeak<T>.tag)
       
       //these definitions will be used during auto-injection
       injectedDefinition = DefinitionOf<Any, InjectedFactory>(factory: { try factory() })
-      injectedDefinition!.scope = scope
+      injectedDefinition?.scope = scope
       
       injectedWeakDefinition = DefinitionOf<AnyObject, InjectedWeakFactory>(factory: {
         guard let result = try factory() as? AnyObject else {
@@ -141,7 +141,7 @@ public final class DefinitionOf<T, F>: Definition {
         }
         return result
       })
-      injectedWeakDefinition!.scope = scope
+      injectedWeakDefinition?.scope = scope
     }
   }
   
@@ -178,7 +178,7 @@ public final class DefinitionOf<T, F>: Definition {
 ///Dummy protocol to store definitions for different types in collection
 public protocol Definition: class { }
 
-protocol AutoInjectedDefinition: Definition {
+protocol _Definition: Definition {
   var injectedDefinition: DefinitionOf<Any, InjectedFactory>? { get }
   var injectedKey: DefinitionKey? { get }
 
@@ -190,7 +190,7 @@ protocol AutoInjectedDefinition: Definition {
   func resolveDependencies(container: DependencyContainer, resolvedInstance: Any) throws
 }
 
-extension DefinitionOf: AutoInjectedDefinition { }
+extension DefinitionOf: _Definition { }
 
 extension DefinitionOf: CustomStringConvertible {
   public var description: String {

--- a/Dip/Dip/Dip.swift
+++ b/Dip/Dip/Dip.swift
@@ -250,7 +250,7 @@ public final class DependencyContainer {
         
         //we perform auto-injection as the last step to be able to reuse instances
         //stored when manually resolving dependencies in resolveDependencies block
-        try resolveDependencies(resolvedInstance)
+        try autoInjectProperties(resolvedInstance)
         
         return resolvedInstance
       }

--- a/Dip/Dip/Dip.swift
+++ b/Dip/Dip/Dip.swift
@@ -25,15 +25,14 @@
 // MARK: - DependencyContainer
 
 /**
-_Dip_'s Dependency Containers allow you to do very simple **Dependency Injection**
-by associating `protocols` to concrete implementations
+`DependencyContainer` allows you to do _Dependency Injection_
+by associating abstractions to concrete implementations.
 */
 public final class DependencyContainer {
   
   /**
-   Use a tag in case you need to register multiple instances or factories
-   with the same protocol, to differentiate them. Tags can be either String
-   or Int, to your convenience.
+   Use a tag in case you need to register multiple factories fo the same type,
+   to differentiate them. Tags can be either String or Int, to your convenience.
    */
   public enum Tag: Equatable {
     case String(StringLiteralType)
@@ -74,47 +73,51 @@ public final class DependencyContainer {
 extension DependencyContainer {
   
   /**
-  Register a Void->T factory associated with optional tag.
-  
-  - parameter tag: The arbitrary tag to associate this factory with when registering with that protocol. Pass `nil` to associate with any tag. Default value is `nil`.
-  - parameter scope: scope to use for this compone
-  - parameter factory: The factory to register, with return type of protocol you want to register it for
-  - returns: definition created for provided type and factory
-  
-  - note: You must cast the factory return type to the protocol you want to register it for.
-  
-  **Example**:
-  ```swift
-  container.register { ServiceImp() as Service }
-  container.register(tag: "service") { ServiceImp() as Service }
-  container.register(.ObjectGraph) { ServiceImp() as Service }
-  container.register { ClientImp(service: try! container.resolve() as Service) as Client }
-  ```
-  */
-  public func register<T>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: () throws -> T) -> DefinitionOf<T, () throws ->T > {
+   Register factory for type `T` and associate it with an optional tag.
+
+   - parameters:
+      - tag: The arbitrary tag to associate this factory with. Pass `nil` to associate with any tag. Default value is `nil`.
+      - scope: The scope to use for instance created by the factory.
+      - factory: The factory to register.
+
+   - returns: A registered definition.
+
+   - note: You should cast the factory return type to the protocol you want to register it for
+           (unless you want to register concrete type).
+
+   **Example**:
+   ```swift
+   container.register { ServiceImp() as Service }
+   container.register(tag: "service") { ServiceImp() as Service }
+   container.register(.ObjectGraph) { ServiceImp() as Service }
+   container.register { ClientImp(service: try! container.resolve() as Service) as Client }
+   ```
+   */
+  public func register<T>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: () throws -> T) -> DefinitionOf<T, () throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory)
   }
   
   /**
-   Register generic factory associated with optional tag.
+   Register generic factory associated with an optional tag.
    
-   - parameter tag: The arbitrary tag to look for when resolving this protocol.
-   - parameter factory: generic factory that should be used to create concrete instance of type
-   - parameter scope: scope of the component. Default value is `Prototype`
-   - returns: definition created for provided type and factory
+   - parameters:
+      - tag: The arbitrary tag to associate this factory with. Pass `nil` to associate with any tag. Default value is `nil`.
+      - scope: The scope to use for instance created by the factory.
+      - factory: The factory to register.
+   
+   - returns: A registered definition.
 
-   - note: You should not call this method directly, instead call any of other `register` methods.
+   - note: You _should not_ call this method directly, instead call any of other `register` methods.
            You _should_ use this method only to register dependency with more runtime arguments
-           than _Dip_ supports (currently it's up to six) like in this example:
+           than _Dip_ supports (currently it's up to six) like in the following example:
    
    ```swift
-   public func register<T, Arg1, Arg2, Arg3, ...>(tag: Tag? = nil, scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, ...) -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, ...) -> T> {
-     return registerFactory(tag: tag, scope: scope, factory: factory) as DefinitionOf<T, (Arg1, Arg2, Arg3, ...) -> T>
+   public func register<T, Arg1, Arg2, Arg3, ...>(tag: Tag? = nil, scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, ...) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, ...) throws -> T> {
+     return registerFactory(tag: tag, scope: scope, factory: factory) as DefinitionOf<T, (Arg1, Arg2, Arg3, ...) throws -> T>
    }
    ```
    
-   Though before you do that you should probably review your design and try to reduce number of depnedencies.
-   
+   Though before you do so you should probably review your design and try to reduce number of depnedencies.
    */
   public func registerFactory<T, F>(tag tag: Tag? = nil, scope: ComponentScope, factory: F) -> DefinitionOf<T, F> {
     let definition = DefinitionOf<T, F>(scope: scope, factory: factory)
@@ -123,11 +126,13 @@ extension DependencyContainer {
   }
   
   /**
-   Registers new definiton in container and associate it with provided tag.
-   Will override already registered definition for the same type and factory associated with the same tag.
+   Register definiton in the container and associate it with an optional tag.
+   Will override already registered definition for the same type and factory, associated with the same tag.
    
-   - parameter tag: The arbitrary tag to associate definition with
-   - parameter definition: definition to register in container
+   - parameters:
+      - tag: The arbitrary tag to associate this definition with. Pass `nil` to associate with any tag. Default value is `nil`.
+      - definition: The definition to register in the container.
+   
    */
   public func register<T, F>(definition: DefinitionOf<T, F>, forTag tag: Tag? = nil) {
     let key = DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: tag)
@@ -147,38 +152,52 @@ extension DependencyContainer {
 extension DependencyContainer {
   
   /**
-  Resolve a dependency.
-  
-  If no definition was registered with this `tag` for this `protocol`,
-  it will try to resolve the definition associated with `nil` (no tag).
-  
-  Will throw `DipError.DefinitionNotFound` if no registered definition found
-  that would match type, runtime arguments and tag.
-  
-  - parameter tag: The arbitrary tag to look for when resolving this protocol.
-  
-  **Example**:
-  ```swift
-  let service = try! container.resolve() as Service
-  let service = try! container.resolve(tag: "service") as Service
-  let service: Service = try! container.resolve()
-  ```
-  
-  */
+   Resolve a an instance of type `T`.
+   
+   If no matching definition was registered with provided `tag`,
+   container will lookup definition associated with `nil` tag.
+   
+   - parameter tag: The arbitrary tag to use to lookup definition.
+   
+   - throws: An error of type `DipError`:
+             `ResolutionFailed` - if some error was thrown during resolution;
+             `DefinitionNotFound` - if no matching definition was registered in that container.
+             `AutoInjectionFailed` - if failed to auto-inject required property
+   
+   - returns: An instance of type `T`.
+   
+   - seealso: `register(tag:_:factory:)`
+   
+   **Example**:
+   ```swift
+   let service = try! container.resolve() as Service
+   let service = try! container.resolve(tag: "service") as Service
+   let service: Service = try! container.resolve()
+   ```
+   
+   */
   public func resolve<T>(tag tag: Tag? = nil) throws -> T {
     return try resolve(tag: tag) { (factory: () throws -> T) in try factory() }
   }
   
   /**
-   Resolve a dependency using generic builder closure that accepts generic factory and returns created instance.
+   Resolve an instance of type `T` using generic builder closure that accepts generic factory and returns created instance.
    
-   - parameter tag: The arbitrary tag to look for when resolving this protocol.
-   - parameter builder: Generic closure that accepts generic factory and returns inctance produced by that factory
-   - returns: resolved instance of type T
+   - parameters:
+      - tag: The arbitrary tag to use to lookup definition.
+      - builder: Generic closure that accepts generic factory and returns inctance created by that factory.
    
-   - note: You should not call this method directly, instead call any of other `resolve` methods. (see `RuntimeArguments.swift`).
-   You _should_ use this method only to resolve dependency with more runtime arguments than _Dip_ supports
-   (currently it's up to six) like in this example:
+   - throws: An error of type `DipError`:
+             `ResolutionFailed` - if some error was thrown during resolution;
+             `DefinitionNotFound` - if no matching definition was registered in that container.
+             `AutoInjectionFailed` - if failed to auto-inject required property
+
+   - returns: An instance of type `T`.
+   
+   - note: You _should not_ call this method directly, instead call any of other 
+           `resolve(tag:)` or `resolve(tag:withArguments:)` methods.
+           You _should_ use this method only to resolve dependency with more runtime arguments than
+           _Dip_ supports (currently it's up to six) like in the following example:
    
    ```swift
    public func resolve<T, Arg1, Arg2, Arg3, ...>(tag tag: Tag? = nil, _ arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, ...) throws -> T {
@@ -186,8 +205,7 @@ extension DependencyContainer {
    }
    ```
    
-   Though before you do that you should probably review your design and try to reduce the number of dependencies.
-   
+   Though before you do so you should probably review your design and try to reduce the number of dependencies.
    */
   public func resolve<T, F>(tag tag: Tag? = nil, builder: F throws -> T) throws -> T {
     let key = DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: tag)
@@ -205,7 +223,7 @@ extension DependencyContainer {
     }
   }
   
-  /// Lookup definition by key or key with `nil` tag and use it to resolve instance.
+  /// Lookup definition by the key and use it to resolve instance. Fallback to the key with `nil` tag.
   func _resolveKey<T, F>(key: DefinitionKey, builder: F throws -> T) throws -> T {
     return try threadSafe {
       let nilTagKey = key.associatedTag.map { _ in DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: nil) }
@@ -366,18 +384,15 @@ public func ==(lhs: DependencyContainer.Tag, rhs: DependencyContainer.Tag) -> Bo
 /**
  Errors thrown by `DependencyContainer`'s methods.
  
- `ResolutionFailed` - some error was thrown during resolution.
- 
- `DefinitionNotFound` - no matching definition was registered in that container.
- 
+ - seealso: `resolve(tag:)`
 */
 public enum DipError: ErrorType, CustomStringConvertible {
   /**
   Thrown by `resolve(tag:)` if some error was thrown during resolution.
    
    - parameters:
-      - key: definition key associated with used definition
-      - underlyingError: the error that caused resolution to fail
+      - key: The key, which is associated with definition used to resolve instance
+      - underlyingError: The error that caused resolution to fail
    */
   case ResolutionFailed(key: DefinitionKey, underlyingError: ErrorType)
   
@@ -388,14 +403,22 @@ public enum DipError: ErrorType, CustomStringConvertible {
   */
   case DefinitionNotFound(key: DefinitionKey)
 
-  case AutoInjectionFailed(String?, Any.Type, ErrorType)
+  /**
+   Thrown by `resolve(tag:)` if failed to auto-inject required property.
+   
+   - parameters:
+      - label: The name of the property
+      - type: The type of the property
+      - underlyingError: The error that caused auto-injection to fail
+  */
+  case AutoInjectionFailed(label: String?, type: Any.Type, underlyingError: ErrorType)
   
   public var description: String {
     switch self {
     case let .ResolutionFailed(key, error):
       return "Failed to resolve type \(key.protocolType). \(error)"
     case let .DefinitionNotFound(key):
-      return "Failed to resolve type \(key.protocolType) - no definition registered for \(key).\nCheck the tag, type you try to resolve, number, order and types of runtime arguments passed to `resolve()` and match them with registered factories for type \(key.protocolType)."
+      return "No definition registered for \(key).\nCheck the tag, type you try to resolve, number, order and types of runtime arguments passed to `resolve()` and match them with registered factories for type \(key.protocolType)."
     case let .AutoInjectionFailed(label, type, error):
       return "Failed to auto-inject property \"\(label)\" of type \(type). \(error)"
     }

--- a/Dip/Dip/Dip.swift
+++ b/Dip/Dip/Dip.swift
@@ -258,7 +258,7 @@ public final class DependencyContainer {
         
         //we perform auto-injection as the last step to be able to reuse instances
         //stored when manually resolving dependencies in resolveDependencies block
-        resolveDependencies(resolvedInstance)
+        try resolveDependencies(resolvedInstance)
         
         return resolvedInstance
       }
@@ -366,7 +366,7 @@ public enum DipError: ErrorType, CustomStringConvertible {
     switch self {
     case let .DefinitionNotFound(key):
       if let wrappedType = isInjectedTag(key.associatedTag) {
-        return "No definition registered for \(key). Check if you registered factory with no tag and no runtime arguments for type \(wrappedType)."
+        return "Failed to auto-inject property of type \(wrappedType). Check if you registered factory with no tag and no runtime arguments for type \(wrappedType)."
       }
       return "Failed to resolve type \(key.protocolType) - no definition registered for \(key).\nCheck the tag, type you try to resolve, number, order and types of runtime arguments passed to `resolve()` and match them with registered factories for type \(key.protocolType)."
     }

--- a/Dip/Dip/Dip.swift
+++ b/Dip/Dip/Dip.swift
@@ -253,7 +253,11 @@ public final class DependencyContainer {
         
         resolvedInstances.storeResolvedInstance(resolvedInstance, forKey: key, definition: definition)
         definition.resolvedInstance = resolvedInstance
+        
         try definition.resolveDependenciesBlock?(self, resolvedInstance)
+        
+        //we perform auto-injection as the last step to be able to reuse instances
+        //stored when manually resolving dependencies in resolveDependencies block
         resolveDependencies(resolvedInstance)
         
         return resolvedInstance

--- a/Dip/Dip/RuntimeArguments.swift
+++ b/Dip/Dip/RuntimeArguments.swift
@@ -29,15 +29,16 @@ extension DependencyContainer {
   // MARK: 1 Runtime Argument
   
   /**
-  Registers factory that accepts one runtime argument. You can use up to six runtime arguments.
-  
-  - parameter tag: The arbitrary tag to associate this factory with when registering with that protocol.
-                   Pass `nil` to associate with any tag. Default value is `nil`.
-  - parameter factory: The factory to register, with return type of protocol you want to register it for
-  
-  - note: You can have several factories with different number or types of arguments registered to for same type.
-          When you resolve it container will match the type and tag as well as __number__, __types__ and __order__
-          of runtime arguments that you pass to `resolve` method.
+  Register factory that accepts one runtime argumentof type `Arg1`. You can use up to six runtime arguments.
+
+  - note: You can have several factories with different number or types of arguments registered for same type,
+          optionally associated with some tags. When container resolves that type it matches the type,
+          __number__, __types__ and __order__ of runtime arguments and optional tag that you pass to `resolve(tag:withArguments:)` method.
+
+  - parameters:
+    - tag: The arbitrary tag to associate this factory with. Pass `nil` to associate with any tag. Default value is `nil`.
+    - scope: The scope to use for this component. Default value is `.Prototype`.
+    - factory: The factory to register.
   
   - seealso: `registerFactory(tag:scope:factory:)`
   */
@@ -46,13 +47,19 @@ extension DependencyContainer {
   }
   
   /**
-   Resolve a dependency with runtime argument. Factories will be matched by tag and the type to resolve as well
-   as __number__, __types__ and __order__ of runtime arguments that you pass to this method.
+   Resolve a dependency using one runtime argument.
    
-   - parameter tag: The arbitrary tag to look for when resolving this protocol.
-   - parameter arg1: First argument to be passed to factory
+   - parameters:
+      - tag: The arbitrary tag to lookup registered definition.
+      - arg1: The first argument to pass to the definition's factory.
    
-   - seealso: `resolve(tag:builder:)`
+   - throws: An error of type `DipError`:
+             `ResolutionFailed` - if some error was thrown during resolution;
+             `DefinitionNotFound` - if no matching definition was registered in that container.
+
+   - returns: An instance of type `T`.
+
+   - seealso: `register(tag:_:factory:)`, `resolve(tag:builder:)`
    */
   public func resolve<T, Arg1>(tag tag: Tag? = nil, withArguments arg1: Arg1) throws -> T {
     return try resolve(tag: tag) { (factory: (Arg1) throws -> T) in try factory(arg1) }
@@ -60,7 +67,7 @@ extension DependencyContainer {
   
   // MARK: 2 Runtime Arguments
   
-  /// - seealso: `register(:factory:scope:)`
+  /// - seealso: `register(tag:scope:factory:)`
   public func register<T, Arg1, Arg2>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2) throws -> T) -> DefinitionOf<T, (Arg1, Arg2) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory)
   }
@@ -72,6 +79,7 @@ extension DependencyContainer {
 
   // MARK: 3 Runtime Arguments
   
+  /// - seealso: `register(tag:scope:factory:)`
   public func register<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory)
   }
@@ -83,6 +91,7 @@ extension DependencyContainer {
   
   // MARK: 4 Runtime Arguments
   
+  /// - seealso: `register(tag:scope:factory:)`
   public func register<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory)
   }
@@ -94,6 +103,7 @@ extension DependencyContainer {
 
   // MARK: 5 Runtime Arguments
   
+  /// - seealso: `register(tag:scope:factory:)`
   public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4, Arg5) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4, Arg5) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory)
   }
@@ -105,6 +115,7 @@ extension DependencyContainer {
 
   // MARK: 6 Runtime Arguments
   
+  /// - seealso: `register(tag:scope:factory:)`
   public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory)
   }

--- a/Dip/Dip/Utils.swift
+++ b/Dip/Dip/Utils.swift
@@ -42,24 +42,3 @@ extension Optional {
     return self.map { "\($0)" } ?? "nil"
   }
 }
-
-extension String {
-  func match(pattern: String) throws -> [String]? {
-    let expr = try NSRegularExpression(pattern: pattern, options: NSRegularExpressionOptions())
-    let result = expr.firstMatchInString(self, options: NSMatchingOptions(), range: NSMakeRange(0, characters.count))
-    return result?.allRanges.flatMap(safeSubstringWithRange)
-  }
-  
-  func safeSubstringWithRange(range: NSRange) -> String? {
-    if NSMaxRange(range) <= self.characters.count {
-      return (self as NSString).substringWithRange(range)
-    }
-    return nil
-  }
-}
-
-extension NSTextCheckingResult {
-  var allRanges: [NSRange] {
-    return (0..<numberOfRanges).map(rangeAtIndex)
-  }
-}

--- a/Dip/Dip/Utils.swift
+++ b/Dip/Dip/Utils.swift
@@ -1,0 +1,65 @@
+//
+// Dip
+//
+// Copyright (c) 2015 Olivier Halligon <olivier@halligon.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import Foundation
+
+extension Dictionary {
+  subscript(key: Key?) -> Value? {
+    get {
+      guard let key = key else { return nil }
+      return self[key]
+    }
+    set {
+      guard let key = key else { return }
+      self[key] = newValue
+    }
+  }
+}
+
+extension Optional {
+  var desc: String {
+    return self.map { "\($0)" } ?? "nil"
+  }
+}
+
+extension String {
+  func match(pattern: String) throws -> [String]? {
+    let expr = try NSRegularExpression(pattern: pattern, options: NSRegularExpressionOptions())
+    let result = expr.firstMatchInString(self, options: NSMatchingOptions(), range: NSMakeRange(0, characters.count))
+    return result?.allRanges.flatMap(safeSubstringWithRange)
+  }
+  
+  func safeSubstringWithRange(range: NSRange) -> String? {
+    if NSMaxRange(range) <= self.characters.count {
+      return (self as NSString).substringWithRange(range)
+    }
+    return nil
+  }
+}
+
+extension NSTextCheckingResult {
+  var allRanges: [NSRange] {
+    return (0..<numberOfRanges).map(rangeAtIndex)
+  }
+}

--- a/Dip/DipTests/AutoInjectionTests.swift
+++ b/Dip/DipTests/AutoInjectionTests.swift
@@ -85,6 +85,8 @@ class AutoInjectionTests: XCTestCase {
       return _server.value
     }
     
+    var taggedServer = Injected<Server>(tag: "tagged")
+
   }
 
   let container = DependencyContainer()
@@ -99,7 +101,7 @@ class AutoInjectionTests: XCTestCase {
     AutoInjectionTests.serverDidInjectCalled = false
   }
 
-  func testThatItResolvesInjectedDependencies() {
+  func testThatItResolvesAutoInjectedDependencies() {
     container.register(.ObjectGraph) { ServerImp() as Server }
     container.register(.ObjectGraph) { ClientImp() as Client }
     
@@ -274,6 +276,23 @@ class AutoInjectionTests: XCTestCase {
     catch {
       XCTFail("Container should not throw error if failed to resolve optional auto-injected properties")
     }
+  }
+  
+  func testThatItResolvesAutoInjectedTaggedDependencies() {
+    //given
+    container.register(.ObjectGraph) { ServerImp() as Server }
+    container.register(tag: "tagged", .ObjectGraph) { ServerImp() as Server }
+    container.register(.ObjectGraph) { ClientImp() as Client }
+    
+    //when
+    let client = try! container.resolve() as Client
+    
+    //then
+    let taggedServer = (client as! ClientImp).taggedServer.value!
+    let server = client.server!
+    
+    //server and tagged server should be resolved as different instances
+    XCTAssertTrue(server !== taggedServer)
   }
   
 }

--- a/Dip/DipTests/AutoInjectionTests.swift
+++ b/Dip/DipTests/AutoInjectionTests.swift
@@ -264,18 +264,6 @@ class AutoInjectionTests: XCTestCase {
     XCTAssertTrue(AutoInjectionTests.serverDidInjectCalled)
   }
   
-  func testThatRemovingDefinitionAlsoRemovesAutoInjectionDefinitions() {
-    let def = container.register(.ObjectGraph) { ServerImp() as Server }
-    
-    XCTAssertTrue(container.definitions.contains { $0.1 === def.injectedDefinition })
-    XCTAssertTrue(container.definitions.contains { $0.1 === def.injectedWeakDefinition })
-    
-    container.remove(def)
-    
-    XCTAssertFalse(container.definitions.contains { $0.1 === def.injectedDefinition })
-    XCTAssertFalse(container.definitions.contains { $0.1 === def.injectedWeakDefinition })
-  }
-  
   func testThatOptionalPropertiesAreNotInjectedAndErrorNotThrown() {
     container.register(.ObjectGraph) { ServerImp() as Server }
     container.register(.ObjectGraph) { ClientImp() as Client }

--- a/Dip/DipTests/AutoInjectionTests.swift
+++ b/Dip/DipTests/AutoInjectionTests.swift
@@ -167,7 +167,7 @@ class AutoInjectionTests: XCTestCase {
     XCTAssertTrue(clientBlockWasCalled)
   }
   
-  func testThatItReuseResolvedAutoInjectedInstences() {
+  func testThatItReuseResolvedAutoInjectedInstances() {
     //given
     container.register(.ObjectGraph) { ServerImp() as Server }
       .resolveDependencies { (container, server) -> () in

--- a/Dip/DipTests/AutoInjectionTests.swift
+++ b/Dip/DipTests/AutoInjectionTests.swift
@@ -27,13 +27,14 @@ import XCTest
 
 private protocol Server: class {
   weak var client: Client? {get}
-  
   var anotherClient: Client? {get set}
+  var optionalClient: AnyObject? {get}
 }
 
 private protocol Client: class {
   var server: Server? {get}
   var anotherServer: Server? {get set}
+  var optionalServer: AnyObject? {get}
 }
 
 class AutoInjectionTests: XCTestCase {
@@ -59,6 +60,9 @@ class AutoInjectionTests: XCTestCase {
     }
     
     weak var anotherClient: Client?
+    
+    weak var _optionalClient = InjectedWeak<AnyObject>(required: false)
+    var optionalClient: AnyObject? { return _optionalClient?.value }
   }
   
   private class ClientImp: Client {
@@ -72,6 +76,10 @@ class AutoInjectionTests: XCTestCase {
     }
     
     var anotherServer: Server?
+    
+    var _optionalServer = Injected<AnyObject>(required: false)
+    
+    var optionalServer: AnyObject? { return _optionalServer.value }
     
     var server: Server? {
       return _server.value
@@ -266,6 +274,18 @@ class AutoInjectionTests: XCTestCase {
     
     XCTAssertFalse(container.definitions.contains { $0.1 === def.injectedDefinition })
     XCTAssertFalse(container.definitions.contains { $0.1 === def.injectedWeakDefinition })
+  }
+  
+  func testThatOptionalPropertiesAreNotInjectedAndErrorNotThrown() {
+    container.register(.ObjectGraph) { ServerImp() as Server }
+    container.register(.ObjectGraph) { ClientImp() as Client }
+
+    do {
+      try container.resolve() as Client
+    }
+    catch {
+      XCTFail("Container should not throw error if failed to resolve optional auto-injected properties")
+    }
   }
   
 }

--- a/Dip/DipTests/AutoInjectionTests.swift
+++ b/Dip/DipTests/AutoInjectionTests.swift
@@ -100,6 +100,16 @@ class AutoInjectionTests: XCTestCase {
     XCTAssertTrue(client === server?.client)
   }
   
+  func testThatItThrowsErrorIfFailsToInjectDependency() {
+    container.register(.ObjectGraph) { ClientImp() as Client }
+    
+    do {
+      try container.resolveDependencies(ClientImp())
+      XCTFail("Resolve should throw error")
+    }
+    catch { }
+  }
+
   func testThatThereIsNoRetainCycleForCyrcularDependencies() {
     //given
     container.register(.ObjectGraph) { ServerImp() as Server }
@@ -245,5 +255,17 @@ class AutoInjectionTests: XCTestCase {
     XCTAssertTrue(AutoInjectionTests.clientDidInjectCalled)
     XCTAssertTrue(AutoInjectionTests.serverDidInjectCalled)
   }
-
+  
+  func testThatRemovingDefinitionAlsoRemovesAutoInjectionDefinitions() {
+    let def = container.register(.ObjectGraph) { ServerImp() as Server }
+    
+    XCTAssertTrue(container.definitions.contains { $0.1 === def.injectedDefinition })
+    XCTAssertTrue(container.definitions.contains { $0.1 === def.injectedWeakDefinition })
+    
+    container.remove(def)
+    
+    XCTAssertFalse(container.definitions.contains { $0.1 === def.injectedDefinition })
+    XCTAssertFalse(container.definitions.contains { $0.1 === def.injectedWeakDefinition })
+  }
+  
 }

--- a/Dip/DipTests/ComponentScopeTests.swift
+++ b/Dip/DipTests/ComponentScopeTests.swift
@@ -53,7 +53,7 @@ class ComponentScopeTests: XCTestCase {
     let service2 = try! container.resolve() as Service
     
     //then
-    XCTAssertFalse((service1 as! ServiceImp1) === (service2 as! ServiceImp1))
+    XCTAssertFalse(service1 === service2)
   }
   
   func testThatItReusesInstanceForSingletonScope() {
@@ -65,7 +65,7 @@ class ComponentScopeTests: XCTestCase {
     let service2 = try! container.resolve() as Service
     
     //then
-    XCTAssertTrue((service1 as! ServiceImp1) === (service2 as! ServiceImp1))
+    XCTAssertTrue(service1 === service2)
   }
   
   class Server {

--- a/Dip/DipTests/ComponentScopeTests.swift
+++ b/Dip/DipTests/ComponentScopeTests.swift
@@ -122,15 +122,20 @@ class ComponentScopeTests: XCTestCase {
     var service2: Service?
     container.register(.ObjectGraph) { ServiceImp1() as Service }.resolveDependencies { (c, _) in
       service2 = try c.resolve(tag: "service") as Service
+      
+      //then
+
+      //when service1 is resolved using this definition due to fallback to nil tag
+      //we don't want every next resolve of service reuse it
+      XCTAssertTrue(service2 is ServiceImp2)
     }
     container.register(tag: "service", .ObjectGraph) { ServiceImp2() as Service}
     
     //when
     let service1 = try! container.resolve(tag: "tag") as Service
-    
+
     //then
     XCTAssertTrue(service1 is ServiceImp1)
-    XCTAssertTrue(service2 is ServiceImp2)
   }
 
 }

--- a/Dip/DipTests/DefinitionTests.swift
+++ b/Dip/DipTests/DefinitionTests.swift
@@ -65,4 +65,33 @@ class DefinitionTests: XCTestCase {
     XCTAssertNotEqual(keyWithDifferentTag1.hashValue, keyWithDifferentTag2.hashValue)
   }
 
+  func testThatResolveDependenciesCallsResolveDependenciesBlockWhen() {
+    var blockCalled = false
+    
+    //given
+    let def = DefinitionOf<Service, () -> Service>(scope: .Prototype) { ServiceImp1() as Service }.resolveDependencies { container, service in
+      blockCalled = true
+    }
+    
+    //when
+   try! def.resolveDependencies(DependencyContainer(), resolvedInstance: ServiceImp1())
+    
+    //then
+    XCTAssertTrue(blockCalled)
+  }
+  
+  func testThatResolveDependenciesBlockIsNotCalledWhenPassedWrongInstance() {
+    var blockCalled = false
+    
+    //given
+    let def = DefinitionOf<Service, () -> Service>(scope: .Prototype) { ServiceImp1() as Service }.resolveDependencies { container, service in
+      blockCalled = true
+    }
+    
+    //when
+    try! def.resolveDependencies(DependencyContainer(), resolvedInstance: String())
+    
+    //then
+    XCTAssertFalse(blockCalled)
+  }
 }

--- a/Dip/DipTests/DipTests.swift
+++ b/Dip/DipTests/DipTests.swift
@@ -25,7 +25,7 @@
 import XCTest
 @testable import Dip
 
-protocol Service {
+protocol Service: class {
   func getServiceName() -> String
 }
 

--- a/DipPlayground.playground/Pages/Auto-injection.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Auto-injection.xcplaygroundpage/Contents.swift
@@ -56,20 +56,44 @@ autoInjectedService.logger
 autoInjectedService.tracker
 
 /*:
-The same you can do if you already have an instance of service and just want to resolve its dependencies:
-*/
-
-let providedService = AutoInjectedServiceImp()
-container.resolveDependencies(providedService)
-providedService.logger
-providedService.tracker
-
-/*:
 As you can see we added two private properties to our implementation of `Service` - `injectedLogger` and `injectedTracker`. Their types are `Injeceted<Logger>` and `Injected<Tracker>` respectively. Note that we've not just defined them as properties of those types, but defined them with some initial value. `Injected<T>` is a simple _wrapper class_ that wraps value of generic type and provides read-write access to it with `value` property. This property is defined as optional, so that when we create instance of `Injected<T>` it will have `nil` in its value. There is also another wrapper - `InjectedWeak<T>` - which in contrast to `Injected<T>` holds a week reference to its wrapped object, thus requiring it to be a _reference type_ (or `AnyObject`), when `Injected<T>` can also wrap value types (or `Any`).
 
 What is happening under the hood is that after concrete instance of resolved type is created (`Service` in that case), container will iterate through its properties using `Mirror`. For each of the properties wrapped with `Injected<T>` or `InjectedWeak<T>` it will search a definition that can be used to create an instance of wrapped type and use it to create and inject a concrete instance in a `value` property of a wrapper. The fact that wrappers are _classes_ or _reference types_ makes it possible at runtime to inject dependency in instance of resolved type.
 
-Another example of using auto-injection is circular dependencies. Let's say you have a `Server` and a `ServerClient` both referencing each other. Standard way to register such components in `DependencyContainer` will lead to such code:
+You can provide closure that will be called when the dependency will be injected in the property. It is similar to `didSet` property observer.
+
+Auto-injected properties can be marked with tag. Then container will search for definition tagged by the same tag to resolve this property.
+
+Auto-injected properties are required by default. That means that if container fails to resolve any of auto-injected properties of the instance (or any of its dependencies) it will fail resolution of the object graph in whole.
+*/
+
+class ServerWithRequiredClient {
+    var client = Injected<Client>()
+}
+
+container.register { ServerWithRequiredClient() }
+
+do {
+    let serverWithClient = try container.resolve() as ServerWithRequiredClient
+}
+catch {
+    print(error)
+}
+
+/*:
+You can make auto-injected property optional by passing `false` to `required` parameter of `Injected<T>`/`InjectedWeak<T>` constructor. For such properties container will ignore any errors when it resolves this property (or any of its dependencies).
+*/
+
+class ServerWithOptionalClient {
+    var optionalClient = Injected<Client>(required: false)
+}
+
+container.register { ServerWithOptionalClient() }
+let serverWithNoClient = try! container.resolve() as ServerWithOptionalClient
+serverWithNoClient.optionalClient.value
+
+/*:
+Another example of using auto-injection is circular dependencies. Let's say you have a `Server` and a `ServerClient` both referencing each other.
 */
 
 protocol Server: class {
@@ -91,6 +115,10 @@ class ServerClientImp: ServerClient {
         self.server = server
     }
 }
+
+/*:
+The standard way to register such components in `DependencyContainer` will lead to such code:
+*/
 
 container.register(.ObjectGraph) {
     ServerClientImp(server: try container.resolve()) as ServerClient
@@ -126,9 +154,9 @@ injectedClient.server
 injectedClient.server?.client === injectedClient //circular dependencies were resolved correctly
 
 /*:
-You can see that component registration looks much simpler now. But on the otherside it requires some boilerplate code in implementations, also tightly coupling them with Dip.
+You can see that component registration looks much simpler now. But on the other side it requires some boilerplate code in implementations, and also tightly coupls your code with Dip.
 
-There is one more use case when auto-injection can be very helpful - when you don't create instances by yourself but system creates them for you. It can be view controllers created by Storyboards. Let's say each view controller in your application requires logger, tracker, data layer service, router, etc. You can end up with code like this:
+Here is an example with higher number of dependencies.
 */
 container.register() { RouterImp() as Router }
 container.register() { DataProviderImp() as DataProvider }
@@ -138,18 +166,17 @@ class ViewController: UIViewController {
     var tracker: Tracker?
     var dataProvider: DataProvider?
     var router: Router?
-
-    //it's better not to access container directly in implementation but that's ok for illustration
-    func injectDependencies(container: DependencyContainer) {
-        logger = try! container.resolve() as Logger
-        tracker = try! container.resolve() as Tracker
-        dataProvider = try! container.resolve() as DataProvider
-        router = try! container.resolve() as Router
-    }
 }
 
-let viewController = ViewController()
-viewController.injectDependencies(container)
+container.register { ViewController() }
+    .resolveDependencies { container, controller in
+        controller.logger = try container.resolve() as Logger
+        controller.tracker = try container.resolve() as Tracker
+        controller.dataProvider = try container.resolve() as DataProvider
+        controller.router = try container.resolve() as Router
+}
+
+let viewController = try! container.resolve() as ViewController
 viewController.router
 
 /*:
@@ -157,25 +184,23 @@ With auto-injection you can replace that with something like this:
 */
 
 class AutoInjectedViewController: UIViewController {
-    
     let logger = Injected<Logger>()
     let tracker = Injected<Tracker>()
     let dataProvider = Injected<DataProvider>()
     let router = Injected<Router>()
-
-    func injectDependencies(container: DependencyContainer) {
-        container.resolveDependencies(self)
-    }
 }
 
-let autoViewController = AutoInjectedViewController()
-autoViewController.injectDependencies(container)
+container.register { AutoInjectedViewController() }
+
+let autoViewController = try! container.resolve() as AutoInjectedViewController
 autoViewController.router.value
 
 /*:
-In such scenario you will need to use property injection anyway, so the overhead of adding additional properties for auto-injection is smaller. Also all the boilerplate code of unwrapping injected properties (if you need that) can be moved to extension, cleaning implementation a bit.
+In such scenario when view controller is created by storyboard you will need to use property injection anyway, so the overhead of adding additional properties for auto-injection is smaller. Also all the boilerplate code of unwrapping injected properties (if you need that) can be moved to extension, cleaning implementation a bit.
 
-So as you can see there are certain advantages and disadvatages of using auto-injection. It makes your definitions simpler, especially if there are circular dependencies involved, and lets you get rid of giant constructors overloaded with arguments. But it requires additional properties and some boilerplate code in your implementations, makes your implementatios tightly coupled with Dip. It has also some limitations like that it requires factories for auto-injected types that accept no runtime arguments and have no associated tags to be registered in a container.
+> **Note**: For such cases concider using [DipUI](https://github.com/AliSoftware/Dip-UI). It is a small extension for Dip that allows you to do exactly what we need in this example - inject dependencies in instances created by storyboards. It does not require to use auto-injection feature.
+
+So as you can see there are certain advantages and disadvatages of using auto-injection. It makes your definitions simpler, especially if there are circular dependencies involved or the number of dependencies is high. But it requires additional properties and some boilerplate code in your implementations, makes your implementatios tightly coupled with Dip. It has also some limitations like that it requires factories for auto-injected types that accept no runtime arguments to be registered in a container.
 
 So you should decide for yourself whether you prefer to use auto-injection or "the standard" way. At the end they let you achieve the same result.
 */


### PR DESCRIPTION
With this PR I try to make property auto-injection rules more strict thus safer. 

Generally property injection is less safe than constructor injection and should be used mostly in situations where dependency is optional because there is a good default implementation. Swift actually makes property injection almost unneeded with default arguments values. But still there could be cases when property injection is more correct than constructor injection (i.e. when instance is always created not by user code, but by system - that can be view controller created by storyboard).

I think that properties that should be auto-injected by Dip should be managed and created only by container. Otherwise user can replace underlying value with manually created instance that can be not fully constructed (if it also uses property injection). So it will be safer if they would be readonly for client code. We can not prevent defining properties as `var`s but we can make `value` property of wrapper readonly, making it impossible to create wrapper by any means except container.

This also makes auto-injected properties required readonly properties and make sure that dependency will be always set, or resolve would fail completely. Originally error was caught and Dip moved to the next property.

It also reduces chances of coupling with Dip by preventing user from using auto-injection wrappers anywhere but property definition.

Also in this PR I add blocks to wrappers that behave like `didSet` observers for standard Swift properties. If user already have some property injected manually with `didSet` observer he can use this block in the same way when/if he decide to use auto-injection for that property.

If users will find these rules too strict and not practical we can change that later without breaking backward compatibility.