### PR TITLE
Singleton scope fixed

### DIFF
--- a/Dip/DipTests/ComponentScopeTests.swift
+++ b/Dip/DipTests/ComponentScopeTests.swift
@@ -68,6 +68,48 @@ class ComponentScopeTests: XCTestCase {
     XCTAssertTrue(service1 === service2)
   }
   
+  func testThatSingletonIsNotReusedAcrossContainers() {
+    //given
+    let def = container.register(.Singleton) { ServiceImp1() as Service }
+    let secondContainer = DependencyContainer()
+    secondContainer.register(def, forTag: nil)
+    
+    //when
+    let service1 = try! container.resolve() as Service
+    let service2 = try! secondContainer.resolve() as Service
+    
+    //then
+    XCTAssertTrue(service1 !== service2, "Singleton instances should not be reused across containers")
+  }
+  
+  func testThatSingletonIsReleasedWhenDefinitionIsRemoved() {
+    //given
+    let def = container.register(.Singleton) { ServiceImp1() as Service }
+    let service1 = try! container.resolve() as Service
+    
+    //when
+    container.remove(def, forTag: nil)
+    container.register(def, forTag: nil)
+    
+    //then
+    let service2 = try! container.resolve() as Service
+    XCTAssertTrue(service1 !== service2, "Singleton instances should be released when definition is removed from the container")
+  }
+  
+  func testThatSingletonIsReleasedWhenContainerIsReset() {
+    //given
+    let def = container.register(.Singleton) { ServiceImp1() as Service }
+    let service1 = try! container.resolve() as Service
+    
+    //when
+    container.reset()
+    container.register(def, forTag: nil)
+    
+    //then
+    let service2 = try! container.resolve() as Service
+    XCTAssertTrue(service1 !== service2, "Singleton instances should be released when container is reset")
+  }
+  
   class Server {
     weak var client: Client?
     

--- a/Dip/DipTests/DefinitionTests.swift
+++ b/Dip/DipTests/DefinitionTests.swift
@@ -74,7 +74,7 @@ class DefinitionTests: XCTestCase {
     }
     
     //when
-   try! def.resolveDependencies(DependencyContainer(), resolvedInstance: ServiceImp1())
+    try! def.resolveDependenciesOf(ServiceImp1(), withContainer: DependencyContainer())
     
     //then
     XCTAssertTrue(blockCalled)
@@ -89,7 +89,7 @@ class DefinitionTests: XCTestCase {
     }
     
     //when
-    try! def.resolveDependencies(DependencyContainer(), resolvedInstance: String())
+    try! def.resolveDependenciesOf(String(), withContainer: DependencyContainer())
     
     //then
     XCTAssertFalse(blockCalled)

--- a/Sources/AutoInjection.swift
+++ b/Sources/AutoInjection.swift
@@ -22,8 +22,6 @@
 // THE SOFTWARE.
 //
 
-//MARK: Public
-
 extension DependencyContainer {
   
   /**

--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -102,7 +102,8 @@ public final class DefinitionOf<T, F>: Definition {
     return self
   }
   
-  func resolveDependencies(container: DependencyContainer, resolvedInstance: Any) throws {
+  /// Calls `resolveDependencies` block if it was set.
+  func resolveDependenciesOf(resolvedInstance: Any, withContainer container: DependencyContainer) throws {
     guard let resolvedInstance = resolvedInstance as? T else { return }
     try self.resolveDependenciesBlock?(container, resolvedInstance)
   }
@@ -139,7 +140,7 @@ public protocol Definition: class { }
 protocol _Definition: Definition {
 
   var scope: ComponentScope { get }
-
+  func resolveDependenciesOf(resolvedInstance: Any, withContainer container: DependencyContainer) throws
 }
 
 extension DefinitionOf: _Definition { }

--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -53,11 +53,80 @@ public func ==(lhs: DefinitionKey, rhs: DefinitionKey) -> Bool {
 
 ///Component scope defines a strategy used by the `DependencyContainer` to manage resolved instances life cycle.
 public enum ComponentScope {
-  /// A new instance will be created each time it's resolved.
+  /**
+   A new instance will be created every time it's resolved.
+   This is a default strategy. Use this strategy when you don't want instances to be shared
+   between different consumers (i.e. if it is not thread safe).
+   
+   **Example**:
+   
+   ```
+   container.register { ServiceImp() as Service }
+   container.register { 
+     ServiceConsumerImp(
+       service1: try container.resolve() as Service
+       service2: try container.resolve() as Service
+     ) as ServiceConsumer
+   }
+   let consumer = container.resolve() as ServiceConsumer
+   consumer.service1 !== consumer.service2 //true
+   
+   ```
+   */
   case Prototype
-  /// Resolved instances will be reused until topmost `resolve(tag:)` method returns.
+  
+  /**
+   Instance resolved with the same definition will be reused until topmost `resolve(tag:)` method returns.
+   When you resolve the same object graph again the container will create new instances.
+   Use this strategy if you want different object in objects graph to share the same instance.
+   
+   - warning: Make sure this component is thread safe or accessed always from the same thread.
+   
+   **Example**:
+   
+   ```
+   container.register(.ObjectGraph) { ServiceImp() as Service }
+   container.register {
+     ServiceConsumerImp(
+       service1: try container.resolve() as Service
+       service2: try container.resolve() as Service
+     ) as ServiceConsumer
+   }
+   let consumer1 = container.resolve() as ServiceConsumer
+   let consumer2 = container.resolve() as ServiceConsumer
+   consumer1.service1 === consumer1.service2 //true
+   consumer2.service1 === consumer2.service2 //true
+   consumer1.service1 !== consumer2.service1 //true
+   ```
+   */
   case ObjectGraph
-  /// Resolved instance will be retained by the container and always reused. Do not mix this lifecycle with _singleton pattern_. Instance will be not shared between defferent containers.
+
+  /**
+   Resolved instance will be retained by the container and always reused.
+   Do not mix this life cycle with _singleton pattern_.
+   Instance will be not shared between defferent containers.
+   
+   - warning: Make sure this component is thread safe or accessed always from the same thread.
+   
+   - note: When you remove definition from the container an instance that was resolved with this definition will be released. When you reset the container it will release all singleton instances.
+   
+   **Example**:
+   
+   ```
+   container.register(.Singleton) { ServiceImp() as Service }
+   container.register {
+     ServiceConsumerImp(
+       service1: try container.resolve() as Service
+       service2: try container.resolve() as Service
+     ) as ServiceConsumer
+   }
+   let consumer1 = container.resolve() as ServiceConsumer
+   let consumer2 = container.resolve() as ServiceConsumer
+   consumer1.service1 === consumer1.service2 //true
+   consumer2.service1 === consumer2.service2 //true
+   consumer1.service1 === consumer2.service1 //true
+   ```
+   */
   case Singleton
 }
 

--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -126,9 +126,7 @@ public final class DefinitionOf<T, F>: Definition {
 public protocol Definition: class { }
 
 protocol _Definition: Definition {
-
   var scope: ComponentScope { get }
-  func resolveDependenciesOf(resolvedInstance: Any, withContainer container: DependencyContainer) throws
 }
 
 extension DefinitionOf: _Definition { }

--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -104,7 +104,7 @@ public enum ComponentScope {
   /**
    Resolved instance will be retained by the container and always reused.
    Do not mix this life cycle with _singleton pattern_.
-   Instance will be not shared between defferent containers.
+   Instance will be not shared between different containers.
    
    - warning: Make sure this component is thread safe or accessed always from the same thread.
    

--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -57,7 +57,7 @@ public enum ComponentScope {
   case Prototype
   /// Resolved instances will be reused until topmost `resolve(tag:)` method returns.
   case ObjectGraph
-  /// Resolved instance will be retained by the container and always reused. Instance is retained not by container itself but by corresponding definition. Do not mix this lifecycle with _singleton pattern_. Instance will be not shared between defferent containers.
+  /// Resolved instance will be retained by the container and always reused. Do not mix this lifecycle with _singleton pattern_. Instance will be not shared between defferent containers.
   case Singleton
 }
 
@@ -118,18 +118,6 @@ public final class DefinitionOf<T, F>: Definition {
     self.scope = scope
   }
   
-  ///Will be stored only if scope is `Singleton`
-  var resolvedInstance: T? {
-    get {
-      guard scope == .Singleton else { return nil }
-      return _resolvedInstance
-    }
-    set {
-      guard scope == .Singleton else { return }
-      _resolvedInstance = newValue
-    }
-  }
-  
   private var _resolvedInstance: T?
   
 }
@@ -147,7 +135,7 @@ extension DefinitionOf: _Definition { }
 
 extension DefinitionOf: CustomStringConvertible {
   public var description: String {
-    return "type: \(T.self), factory: \(F.self), scope: \(scope), resolved instance: \(resolvedInstance.desc)"
+    return "type: \(T.self), factory: \(F.self), scope: \(scope)"
   }
 }
 

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -326,6 +326,7 @@ extension DependencyContainer {
   func remove(definitionForKey key: DefinitionKey) {
     threadSafe {
       definitions[key] = nil
+      resolvedInstances.singletons[key] = nil
     }
   }
 
@@ -335,6 +336,7 @@ extension DependencyContainer {
   public func reset() {
     threadSafe {
       definitions.removeAll()
+      resolvedInstances.singletons.removeAll()
     }
   }
 

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -258,7 +258,7 @@ extension DependencyContainer {
         resolvedInstances.storeResolvedInstance(resolvedInstance, forKey: key, definition: definition)
         definition.resolvedInstance = resolvedInstance
         
-        try definition.resolveDependenciesBlock?(self, resolvedInstance)
+        try definition.resolveDependenciesOf(resolvedInstance, withContainer: self)
         
         //we perform auto-injection as the last step to be able to reuse instances
         //stored when manually resolving dependencies in resolveDependencies block

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -233,16 +233,14 @@ extension DependencyContainer {
       guard let definition = (self.definitions[key] ?? self.definitions[nilTagKey]) as? DefinitionOf<T, F> else {
         throw DipError.DefinitionNotFound(key: key)
       }
-      return try self._resolveDefinition(definition, usingKey: (definition.scope == .ObjectGraph ? key : nil), builder: builder)
+      return try self._resolveDefinition(definition, key: key, builder: builder)
     }
   }
   
   /// Actually resolve dependency.
-  private func _resolveDefinition<T, F>(definition: DefinitionOf<T, F>, usingKey key: DefinitionKey?, builder: F throws -> T) rethrows -> T {
-    
+  private func _resolveDefinition<T, F>(definition: DefinitionOf<T, F>, key: DefinitionKey, builder: F throws -> T) rethrows -> T {
     return try resolvedInstances.resolve {
-      
-      if let previouslyResolved: T = resolvedInstances.previouslyResolved(key, definition: definition) {
+      if let previouslyResolved: T = resolvedInstances.previouslyResolvedInstance(forKey: key, inScope: definition.scope) {
         return previouslyResolved
       }
       else {
@@ -251,12 +249,11 @@ extension DependencyContainer {
         //when builder calls factory it will in turn resolve sub-dependencies (if there are any)
         //when it returns instance that we try to resolve here can be already resolved
         //so we return it, throwing away instance created by previous call to builder
-        if let previouslyResolved: T = resolvedInstances.previouslyResolved(key, definition: definition) {
+        if let previouslyResolved: T = resolvedInstances.previouslyResolvedInstance(forKey: key, inScope: definition.scope) {
           return previouslyResolved
         }
         
-        resolvedInstances.storeResolvedInstance(resolvedInstance, forKey: key, definition: definition)
-        definition.resolvedInstance = resolvedInstance
+        resolvedInstances.storeResolvedInstance(resolvedInstance, forKey: key, inScope: definition.scope)
         
         try definition.resolveDependenciesOf(resolvedInstance, withContainer: self)
         
@@ -273,19 +270,22 @@ extension DependencyContainer {
   ///Before `resolve()` returns pool is drained.
   class ResolvedInstances {
     var resolvedInstances = [DefinitionKey: Any]()
+    var singletons = [DefinitionKey: Any]()
 
-    func storeResolvedInstance<T, F>(instance: T, forKey key: DefinitionKey?, definition: DefinitionOf<T, F>) {
-      resolvedInstances[key] = instance
+    func storeResolvedInstance<T>(instance: T, forKey key: DefinitionKey, inScope scope: ComponentScope) {
+      switch scope {
+      case .Singleton: singletons[key] = instance
+      case .ObjectGraph: resolvedInstances[key] = instance
+      case .Prototype: break
+      }
     }
     
-    func previouslyResolved<T, F>(key: DefinitionKey?, definition: DefinitionOf<T, F>) -> T? {
-      if let singleton = definition.resolvedInstance {
-        return singleton
+    func previouslyResolvedInstance<T>(forKey key: DefinitionKey, inScope scope: ComponentScope) -> T? {
+      switch scope {
+      case .Singleton: return singletons[key] as? T
+      case .ObjectGraph: return resolvedInstances[key] as? T
+      case .Prototype: return nil
       }
-      else if let resolved = resolvedInstances[key] {
-        return resolved as? T
-      }
-      return nil
     }
     
     private var depth: Int = 0


### PR DESCRIPTION
The problem is that instances managed using Singleton scope should not be shared between containers. But currently there is a way to register the same definition in different containers, so if we store resolved instance in definition it will be shared between those two containers. In this PR I moved storing such instances in resolved instances pool of the container that is not drained when resolve method returns. So the instances will be properly scoped to containers.