### PR TITLE
DependencyTagConvertible for better typed Tags

### DIFF
--- a/SampleApp/DipSampleApp/DependencyContainers.swift
+++ b/SampleApp/DipSampleApp/DependencyContainers.swift
@@ -17,6 +17,17 @@ private let FAKE_STARSHIPS = false
 /* ---- */
 
 
+enum DependencyTags: Int {
+    case Hardcoded
+    case Dummy
+}
+
+extension DependencyTags: DependencyTagConvertible {
+    func toTag() -> DependencyTag {
+        return DependencyTag.Int(self.rawValue)
+    }
+}
+
 // MARK: Dependency Container for Providers
 func configureContainer(dip: DependencyContainer) {
     
@@ -47,16 +58,16 @@ func configureContainer(dip: DependencyContainer) {
         // 2) Register fake starships provider
         
         //Here we register different implementations for the same protocol using tags
-        dip.register(tag: "hardcoded") { HardCodedStarshipProvider() as StarshipProviderAPI }
+        dip.register(tag: DependencyTags.Hardcoded) { HardCodedStarshipProvider() as StarshipProviderAPI }
         
         //Here we register factory that will require a runtime argument
-        dip.register(tag: "dummy") { DummyStarshipProvider(pilotName: $0) as StarshipProviderAPI }
+        dip.register(tag: DependencyTags.Dummy) { DummyStarshipProvider(pilotName: $0) as StarshipProviderAPI }
         
         //Here we use constructor injection, but instead of providing dependencies manually container resolves them for us
         dip.register() {
             FakeStarshipProvider(
-                dummyProvider: try dip.resolve(tag: "dummy", withArguments: "Main Pilot"),
-                hardCodedProvider: try dip.resolve(tag: "hardcoded")) as StarshipProviderAPI
+                dummyProvider: try dip.resolve(tag: DependencyTags.Dummy, withArguments: "Main Pilot"),
+                hardCodedProvider: try dip.resolve(tag: DependencyTags.Hardcoded)) as StarshipProviderAPI
         }
         
     } else {

--- a/Sources/AutoInjection.swift
+++ b/Sources/AutoInjection.swift
@@ -123,7 +123,7 @@ public final class Injected<T>: _InjectedPropertyBox<T>, AutoInjectedPropertyBox
       - didInject: block that will be called when concrete instance is injected in this property. 
                    Similar to `didSet` property observer. Default value does nothing.
   */
-  public override init(required: Bool = true, tag: DependencyContainer.Tag? = nil, didInject: T -> () = { _ in }) {
+  public override init(required: Bool = true, tag: DependencyTagConvertible? = nil, didInject: T -> () = { _ in }) {
     super.init(required: required, tag: tag, didInject: didInject)
   }
   
@@ -197,7 +197,7 @@ public final class InjectedWeak<T>: _InjectedPropertyBox<T>, AutoInjectedPropert
       - didInject: block that will be called when concrete instance is injected in this property.
                    Similar to `didSet` property observer. Default value does nothing.
    */
-  public override init(required: Bool = true, tag: DependencyContainer.Tag? = nil, didInject: T -> () = { _ in }) {
+  public override init(required: Bool = true, tag: DependencyTagConvertible? = nil, didInject: T -> () = { _ in }) {
     super.init(required: required, tag: tag, didInject: didInject)
   }
   
@@ -216,11 +216,11 @@ private class _InjectedPropertyBox<T> {
 
   let required: Bool
   let didInject: T -> ()
-  let tag: DependencyContainer.Tag?
+  let tag: DependencyTag?
 
-  init(required: Bool = true, tag: DependencyContainer.Tag?, didInject: T -> () = { _ in }) {
+  init(required: Bool = true, tag: DependencyTagConvertible?, didInject: T -> () = { _ in }) {
     self.required = required
-    self.tag = tag
+    self.tag = tag?.toTag()
     self.didInject = didInject
   }
 

--- a/Sources/AutoInjection.swift
+++ b/Sources/AutoInjection.swift
@@ -216,7 +216,7 @@ private class _InjectedPropertyBox<T> {
 
   let required: Bool
   let didInject: T -> ()
-  let tag: DependencyTag?
+  let tag: DependencyContainer.Tag?
 
   init(required: Bool = true, tag: DependencyTagConvertible?, didInject: T -> () = { _ in }) {
     self.required = required

--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -26,9 +26,9 @@
 public struct DefinitionKey : Hashable, CustomStringConvertible {
   public let protocolType: Any.Type
   public let factoryType: Any.Type
-  public let associatedTag: DependencyTag?
+  public let associatedTag: DependencyContainer.Tag?
   
-  init(protocolType: Any.Type, factoryType: Any.Type, associatedTag: DependencyTag? = nil) {
+  init(protocolType: Any.Type, factoryType: Any.Type, associatedTag: DependencyContainer.Tag? = nil) {
     self.protocolType = protocolType
     self.factoryType = factoryType
     self.associatedTag = associatedTag

--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -26,9 +26,9 @@
 public struct DefinitionKey : Hashable, CustomStringConvertible {
   public let protocolType: Any.Type
   public let factoryType: Any.Type
-  public let associatedTag: DependencyContainer.Tag?
+  public let associatedTag: DependencyTag?
   
-  init(protocolType: Any.Type, factoryType: Any.Type, associatedTag: DependencyContainer.Tag? = nil) {
+  init(protocolType: Any.Type, factoryType: Any.Type, associatedTag: DependencyTag? = nil) {
     self.protocolType = protocolType
     self.factoryType = factoryType
     self.associatedTag = associatedTag

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -22,12 +22,8 @@
 // THE SOFTWARE.
 //
 
-public enum DependencyTag: Equatable {
-  case String(StringLiteralType)
-  case Int(IntegerLiteralType)
-}
 
-extension DependencyTag: IntegerLiteralConvertible {
+extension DependencyContainer.Tag: IntegerLiteralConvertible {
   
   public init(integerLiteral value: IntegerLiteralType) {
     self = .Int(value)
@@ -35,7 +31,7 @@ extension DependencyTag: IntegerLiteralConvertible {
   
 }
 
-extension DependencyTag: StringLiteralConvertible {
+extension DependencyContainer.Tag: StringLiteralConvertible {
   
   public init(stringLiteral value: StringLiteralType) {
     self = .String(value)
@@ -51,7 +47,7 @@ extension DependencyTag: StringLiteralConvertible {
   
 }
 
-public func ==(lhs: DependencyTag, rhs: DependencyTag) -> Bool {
+public func ==(lhs: DependencyContainer.Tag, rhs: DependencyContainer.Tag) -> Bool {
   switch (lhs, rhs) {
   case let (.String(lhsString), .String(rhsString)):
     return lhsString == rhsString
@@ -65,24 +61,24 @@ public func ==(lhs: DependencyTag, rhs: DependencyTag) -> Bool {
 
 
 public protocol DependencyTagConvertible {
-  func toTag() -> DependencyTag
+  func toTag() -> DependencyContainer.Tag
 }
 
-extension DependencyTag: DependencyTagConvertible {
-  public func toTag() -> DependencyTag {
+extension DependencyContainer.Tag: DependencyTagConvertible {
+  public func toTag() -> DependencyContainer.Tag {
     return self
   }
 }
 
 extension String: DependencyTagConvertible {
-  public func toTag() -> DependencyTag {
-    return DependencyTag.String(self)
+  public func toTag() -> DependencyContainer.Tag {
+    return DependencyContainer.Tag.String(self)
   }
 }
 
 extension Int: DependencyTagConvertible {
-  public func toTag() -> DependencyTag {
-    return DependencyTag.Int(self)
+  public func toTag() -> DependencyContainer.Tag {
+    return DependencyContainer.Tag.Int(self)
   }
 }
 
@@ -93,6 +89,11 @@ extension Int: DependencyTagConvertible {
 by associating abstractions to concrete implementations.
 */
 public final class DependencyContainer {
+  
+  public enum Tag: Equatable {
+    case String(StringLiteralType)
+    case Int(IntegerLiteralType)
+  }
   
   /**
    Use a tag in case you need to register multiple factories fo the same type,

--- a/Sources/RuntimeArguments.swift
+++ b/Sources/RuntimeArguments.swift
@@ -42,7 +42,7 @@ extension DependencyContainer {
   
   - seealso: `registerFactory(tag:scope:factory:)`
   */
-  public func register<T, Arg1>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1) throws -> T) -> DefinitionOf<T, (Arg1) throws -> T> {
+  public func register<T, Arg1>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1) throws -> T) -> DefinitionOf<T, (Arg1) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory)
   }
   
@@ -61,67 +61,67 @@ extension DependencyContainer {
 
    - seealso: `register(tag:_:factory:)`, `resolve(tag:builder:)`
    */
-  public func resolve<T, Arg1>(tag tag: Tag? = nil, withArguments arg1: Arg1) throws -> T {
+  public func resolve<T, Arg1>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: Arg1) throws -> T {
     return try resolve(tag: tag) { (factory: (Arg1) throws -> T) in try factory(arg1) }
   }
   
   // MARK: 2 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, Arg1, Arg2>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2) throws -> T) -> DefinitionOf<T, (Arg1, Arg2) throws -> T> {
+  public func register<T, Arg1, Arg2>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2) throws -> T) -> DefinitionOf<T, (Arg1, Arg2) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory)
   }
   
   /// - seealso: `resolve(tag:_:)`
-  public func resolve<T, Arg1, Arg2>(tag tag: Tag? = nil, withArguments arg1: Arg1, _ arg2: Arg2) throws -> T {
+  public func resolve<T, Arg1, Arg2>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: Arg1, _ arg2: Arg2) throws -> T {
     return try resolve(tag: tag) { (factory: (Arg1, Arg2) throws -> T) in try factory(arg1, arg2) }
   }
 
   // MARK: 3 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3) throws -> T> {
+  public func register<T, Arg1, Arg2, Arg3>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory)
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
-  public func resolve<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, withArguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) throws -> T {
+  public func resolve<T, Arg1, Arg2, Arg3>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3) throws -> T {
     return try resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3) throws -> T) in try factory(arg1, arg2, arg3) }
   }
   
   // MARK: 4 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4) throws -> T> {
+  public func register<T, Arg1, Arg2, Arg3, Arg4>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory)
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
-  public func resolve<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, withArguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) throws -> T {
+  public func resolve<T, Arg1, Arg2, Arg3, Arg4>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4) throws -> T {
     return try resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4) throws -> T) in try factory(arg1, arg2, arg3, arg4) }
   }
 
   // MARK: 5 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4, Arg5) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4, Arg5) throws -> T> {
+  public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4, Arg5) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4, Arg5) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory)
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
-  public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, withArguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) throws -> T {
+  public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5) throws -> T {
     return try resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5) throws -> T) in try factory(arg1, arg2, arg3, arg4, arg5) }
   }
 
   // MARK: 6 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) throws -> T> {
+  public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory)
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
-  public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: Tag? = nil, withArguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) throws -> T {
+  public func resolve<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: Arg1, _ arg2: Arg2, _ arg3: Arg3, _ arg4: Arg4, _ arg5: Arg5, _ arg6: Arg6) throws -> T {
     return try resolve(tag: tag) { (factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) throws -> T) in try factory(arg1, arg2, arg3, arg4, arg5, arg6) }
   }
 


### PR DESCRIPTION
This offers to remove `Tag` from `register` and `resolve` APIs  in favour of `DependencyTagConvertible` protocol, which may represent Tag itself as well as any other type conforming to this protocol. 
Specifically, this allows me to use custom enums (conforming to `DependencyTagConvertible`) as tags instead of `String` or `Int` literals, making it more type-safe.

I modified SampleApp to use such an enum for tags. [see here](https://github.com/AliSoftware/Dip/compare/develop...gavrix:develop#diff-f678440884b69096a2fcf0b90b04c486R61)

At the same time, it is still possible to use `String` and `Int` literals as tags, so this PR adds more flexibility retaining existing functionality