### PR TITLE
Auto-wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Develop
+
+* Auto-wiring.  
+  [#55](https://github.com/AliSoftware/Dip/pull/55), [@ilyapuchka](https://github.com/ilyapuchka)
+
+
 ## 4.2.0
 
 * Added support for Swift Package Manager.  

--- a/Dip/Dip.xcodeproj/project.pbxproj
+++ b/Dip/Dip.xcodeproj/project.pbxproj
@@ -49,12 +49,19 @@
 		09873F7A1C1E0252000C02F6 /* AutoInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09873F551C1E0237000C02F6 /* AutoInjection.swift */; };
 		09873F7B1C1E0253000C02F6 /* AutoInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09873F551C1E0237000C02F6 /* AutoInjection.swift */; };
 		09873F7C1C1E0254000C02F6 /* AutoInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09873F551C1E0237000C02F6 /* AutoInjection.swift */; };
+		09B035FC1C5D2AD6001EA5B7 /* AutoWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B035FB1C5D2AD6001EA5B7 /* AutoWiringTests.swift */; };
+		09B035FD1C5D2AD6001EA5B7 /* AutoWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B035FB1C5D2AD6001EA5B7 /* AutoWiringTests.swift */; };
+		09B035FE1C5D2AD6001EA5B7 /* AutoWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B035FB1C5D2AD6001EA5B7 /* AutoWiringTests.swift */; };
+		09B036001C5D2B83001EA5B7 /* AutoWiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B035FF1C5D2B83001EA5B7 /* AutoWiring.swift */; };
+		09B036011C5D2B83001EA5B7 /* AutoWiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B035FF1C5D2B83001EA5B7 /* AutoWiring.swift */; };
+		09B036021C5D2B83001EA5B7 /* AutoWiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B035FF1C5D2B83001EA5B7 /* AutoWiring.swift */; };
+		09B036031C5D2B83001EA5B7 /* AutoWiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B035FF1C5D2B83001EA5B7 /* AutoWiring.swift */; };
+		09C20EC11C8B3BFD009A082B /* ThreadSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C20EBF1C8B3BC3009A082B /* ThreadSafetyTests.swift */; };
+		09C20EC21C8B3BFE009A082B /* ThreadSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C20EBF1C8B3BC3009A082B /* ThreadSafetyTests.swift */; };
+		09C20EC31C8B3BFF009A082B /* ThreadSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C20EBF1C8B3BC3009A082B /* ThreadSafetyTests.swift */; };
 		09D598331C6F9EC100F24D49 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D598321C6F9EC100F24D49 /* Utils.swift */; };
 		09D598341C6F9EC100F24D49 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D598321C6F9EC100F24D49 /* Utils.swift */; };
 		09D598351C6F9EC100F24D49 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D598321C6F9EC100F24D49 /* Utils.swift */; };
-		2C15B9511C25F01200EA3486 /* ThreadSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C15B94F1C25EF7800EA3486 /* ThreadSafetyTests.swift */; };
-		2C15B9521C25F01300EA3486 /* ThreadSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C15B94F1C25EF7800EA3486 /* ThreadSafetyTests.swift */; };
-		2C15B9531C25F01500EA3486 /* ThreadSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C15B94F1C25EF7800EA3486 /* ThreadSafetyTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -102,8 +109,10 @@
 		0982AF0B1C5183A000B62463 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Utils.swift; path = ../../Sources/Utils.swift; sourceTree = "<group>"; };
 		09873F551C1E0237000C02F6 /* AutoInjection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AutoInjection.swift; path = ../../Sources/AutoInjection.swift; sourceTree = "<group>"; };
 		09873F751C1E0249000C02F6 /* AutoInjectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AutoInjectionTests.swift; path = Sources/AutoInjectionTests.swift; sourceTree = "<group>"; };
+		09B035FB1C5D2AD6001EA5B7 /* AutoWiringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AutoWiringTests.swift; path = Sources/AutoWiringTests.swift; sourceTree = "<group>"; };
+		09B035FF1C5D2B83001EA5B7 /* AutoWiring.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoWiring.swift; sourceTree = "<group>"; };
+		09C20EBF1C8B3BC3009A082B /* ThreadSafetyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ThreadSafetyTests.swift; path = Sources/ThreadSafetyTests.swift; sourceTree = "<group>"; };
 		09D598321C6F9EC100F24D49 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Utils.swift; path = Sources/Utils.swift; sourceTree = "<group>"; };
-		2C15B94F1C25EF7800EA3486 /* ThreadSafetyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ThreadSafetyTests.swift; path = Sources/ThreadSafetyTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -170,6 +179,7 @@
 				0919F4C81C16417000DC3B10 /* Definition.swift */,
 				0919F4CC1C16417000DC3B10 /* RuntimeArguments.swift */,
 				09873F551C1E0237000C02F6 /* AutoInjection.swift */,
+				09B035FF1C5D2B83001EA5B7 /* AutoWiring.swift */,
 				0982AF0B1C5183A000B62463 /* Utils.swift */,
 				0919F4CB1C16417000DC3B10 /* Info.plist */,
 			);
@@ -184,7 +194,8 @@
 				0919F4D21C16417000DC3B10 /* RuntimeArgumentsTests.swift */,
 				0919F4CE1C16417000DC3B10 /* ComponentScopeTests.swift */,
 				09873F751C1E0249000C02F6 /* AutoInjectionTests.swift */,
-				2C15B94F1C25EF7800EA3486 /* ThreadSafetyTests.swift */,
+				09C20EBF1C8B3BC3009A082B /* ThreadSafetyTests.swift */,
+				09B035FB1C5D2AD6001EA5B7 /* AutoWiringTests.swift */,
 				09D598321C6F9EC100F24D49 /* Utils.swift */,
 				0919F4D11C16417000DC3B10 /* Info.plist */,
 			);
@@ -495,6 +506,7 @@
 			files = (
 				0982AF0C1C5183A000B62463 /* Utils.swift in Sources */,
 				0919F4D51C16417B00DC3B10 /* Definition.swift in Sources */,
+				09B036001C5D2B83001EA5B7 /* AutoWiring.swift in Sources */,
 				0919F4D41C16417B00DC3B10 /* Dip.swift in Sources */,
 				09873F561C1E0237000C02F6 /* AutoInjection.swift in Sources */,
 				0919F4D61C16417B00DC3B10 /* RuntimeArguments.swift in Sources */,
@@ -506,9 +518,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				0919F4E61C16419300DC3B10 /* ComponentScopeTests.swift in Sources */,
-				2C15B9511C25F01200EA3486 /* ThreadSafetyTests.swift in Sources */,
+				09C20EC11C8B3BFD009A082B /* ThreadSafetyTests.swift in Sources */,
 				0919F4E41C16419300DC3B10 /* DefinitionTests.swift in Sources */,
 				09D598331C6F9EC100F24D49 /* Utils.swift in Sources */,
+				09B035FC1C5D2AD6001EA5B7 /* AutoWiringTests.swift in Sources */,
 				0919F4E31C16419300DC3B10 /* DipTests.swift in Sources */,
 				0919F4E51C16419300DC3B10 /* RuntimeArgumentsTests.swift in Sources */,
 				09873F771C1E024E000C02F6 /* AutoInjectionTests.swift in Sources */,
@@ -521,6 +534,7 @@
 			files = (
 				0982AF0D1C5183A000B62463 /* Utils.swift in Sources */,
 				0919F4D91C16417C00DC3B10 /* Definition.swift in Sources */,
+				09B036011C5D2B83001EA5B7 /* AutoWiring.swift in Sources */,
 				0919F4D81C16417C00DC3B10 /* Dip.swift in Sources */,
 				09873F7A1C1E0252000C02F6 /* AutoInjection.swift in Sources */,
 				0919F4DA1C16417C00DC3B10 /* RuntimeArguments.swift in Sources */,
@@ -532,9 +546,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				0919F4EA1C16419400DC3B10 /* ComponentScopeTests.swift in Sources */,
-				2C15B9521C25F01300EA3486 /* ThreadSafetyTests.swift in Sources */,
+				09C20EC21C8B3BFE009A082B /* ThreadSafetyTests.swift in Sources */,
 				0919F4E81C16419400DC3B10 /* DefinitionTests.swift in Sources */,
 				09D598341C6F9EC100F24D49 /* Utils.swift in Sources */,
+				09B035FD1C5D2AD6001EA5B7 /* AutoWiringTests.swift in Sources */,
 				0919F4E71C16419400DC3B10 /* DipTests.swift in Sources */,
 				0919F4E91C16419400DC3B10 /* RuntimeArgumentsTests.swift in Sources */,
 				09873F781C1E024E000C02F6 /* AutoInjectionTests.swift in Sources */,
@@ -547,6 +562,7 @@
 			files = (
 				0982AF0E1C5183A000B62463 /* Utils.swift in Sources */,
 				0919F4DD1C16417D00DC3B10 /* Definition.swift in Sources */,
+				09B036021C5D2B83001EA5B7 /* AutoWiring.swift in Sources */,
 				0919F4DC1C16417D00DC3B10 /* Dip.swift in Sources */,
 				09873F7B1C1E0253000C02F6 /* AutoInjection.swift in Sources */,
 				0919F4DE1C16417D00DC3B10 /* RuntimeArguments.swift in Sources */,
@@ -558,9 +574,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				0919F4EE1C16419500DC3B10 /* ComponentScopeTests.swift in Sources */,
-				2C15B9531C25F01500EA3486 /* ThreadSafetyTests.swift in Sources */,
+				09C20EC31C8B3BFF009A082B /* ThreadSafetyTests.swift in Sources */,
 				0919F4EC1C16419500DC3B10 /* DefinitionTests.swift in Sources */,
 				09D598351C6F9EC100F24D49 /* Utils.swift in Sources */,
+				09B035FE1C5D2AD6001EA5B7 /* AutoWiringTests.swift in Sources */,
 				0919F4EB1C16419500DC3B10 /* DipTests.swift in Sources */,
 				0919F4ED1C16419500DC3B10 /* RuntimeArgumentsTests.swift in Sources */,
 				09873F791C1E024F000C02F6 /* AutoInjectionTests.swift in Sources */,
@@ -573,6 +590,7 @@
 			files = (
 				0982AF0F1C5183A000B62463 /* Utils.swift in Sources */,
 				0919F4E11C16417E00DC3B10 /* Definition.swift in Sources */,
+				09B036031C5D2B83001EA5B7 /* AutoWiring.swift in Sources */,
 				0919F4E01C16417E00DC3B10 /* Dip.swift in Sources */,
 				09873F7C1C1E0254000C02F6 /* AutoInjection.swift in Sources */,
 				0919F4E21C16417E00DC3B10 /* RuntimeArguments.swift in Sources */,

--- a/Dip/Dip/AutoWiring.swift
+++ b/Dip/Dip/AutoWiring.swift
@@ -1,0 +1,101 @@
+//
+// Dip
+//
+// Copyright (c) 2015 Olivier Halligon <olivier@halligon.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+extension DependencyContainer {
+  
+  /// Tries to resolve instance using auto-wire factories
+  func _resolveByAutoWiring<T>(key: DefinitionKey) throws -> T? {
+    typealias NoArgumentsFactory = () throws -> T
+    guard key.factoryType == NoArgumentsFactory.self else { return nil }
+    
+    var autoWiringDefinitionsKeys = self.definitions
+      //filter only definitions with auto-wiring factory
+      .filter({ ($0.1 as? _Definition)?._autoWiringFactory != nil })
+      .map({ $0.0 }) //get definition keys
+
+    autoWiringDefinitionsKeys = autoWiringDefinitionsKeys
+      //filter keys for T and factories with arguments
+      .filter({ $0.protocolType == T.self && $0.numberOfArguments > 0 })
+      //filter keys with the same or nil tag
+      .filter({ $0.associatedTag == key.associatedTag || $0.associatedTag == nil })
+      //sort filtered keys by number of factory arguments
+      .sort({ $0.numberOfArguments > $1.numberOfArguments })
+    
+    guard !autoWiringDefinitionsKeys.isEmpty else { return nil }
+    
+    autoWiringDefinitionsKeys =
+      //first we try tagged definitions
+      autoWiringDefinitionsKeys.filter({ $0.associatedTag == key.associatedTag }) +
+      //if non of them worked we fallback to not-tagged definitions
+      autoWiringDefinitionsKeys.filter({ $0.associatedTag != key.associatedTag })
+    
+    return try _resolveEnumeratingKeys(autoWiringDefinitionsKeys, tag: key.associatedTag)
+  }
+  
+  /// Tries definitions one by one until one of them succeeds, otherwise returns nil
+  private func _resolveEnumeratingKeys<T>(keys: [DefinitionKey], tag: DependencyContainer.Tag?) throws -> T? {
+    for (index, key) in keys.enumerate() {
+      //if this and the next definition have the same number of arguments
+      //we can not choose one of them
+      if let
+        nextKey = keys[next: index] where
+        nextKey.numberOfArguments == key.numberOfArguments &&
+        nextKey.associatedTag == key.associatedTag {
+          throw DipError.AmbiguousDefinitions(key)
+      }
+      
+      if let resolved: T = _resolveKey(key, tag: tag) {
+        return resolved
+      }
+    }
+    return nil
+  }
+  
+  private func _resolveKey<T>(key: DefinitionKey, tag: DependencyContainer.Tag?) -> T? {
+    do {
+      let key = DefinitionKey(protocolType: key.protocolType, factoryType: key.factoryType, associatedTag: tag)
+      
+      return try _resolveKey(key, builder: { definition throws -> T in
+        guard let resolved = try definition._autoWiringFactory!(self, tag) as? T else {
+          fatalError("Internal inconsistency exception! Expected type: \(T.self); Definition: \(definition)")
+        }
+        return resolved
+      })
+    }
+    catch {
+      return nil
+    }
+  }
+  
+}
+
+extension CollectionType {
+  subscript(safe index: Index) -> Generator.Element? {
+    guard indices.contains(index) else { return nil }
+    return self[index]
+  }
+  subscript(next index: Index) -> Generator.Element? {
+    return self[safe: index.advancedBy(1)]
+  }
+}

--- a/Dip/DipTests/Sources/AutoInjectionTests.swift
+++ b/Dip/DipTests/Sources/AutoInjectionTests.swift
@@ -111,7 +111,7 @@ class AutoInjectionTests: XCTestCase {
   }
 
   func setUp() {
-  container.reset()
+    container.reset()
   }
   #else
   override func setUp() {

--- a/Dip/DipTests/Sources/AutoWiringTests.swift
+++ b/Dip/DipTests/Sources/AutoWiringTests.swift
@@ -1,0 +1,313 @@
+//
+// Dip
+//
+// Copyright (c) 2015 Olivier Halligon <olivier@halligon.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import XCTest
+@testable import Dip
+
+private protocol Service: class { }
+private class ServiceImp1: Service { }
+private class ServiceImp2: Service { }
+
+private protocol AutoWiredClient: class {
+  var service1: Service! { get set }
+  var service2: Service! { get set }
+}
+
+private class AutoWiredClientImp: AutoWiredClient {
+  var service1: Service!
+  var service2: Service!
+  
+  init(service1: Service, service2: ServiceImp2) {
+    self.service1 = service1
+    self.service2 = service2
+  }
+  init() {}
+}
+
+class AutoWiringTests: XCTestCase {
+  
+  let container = DependencyContainer()
+
+  #if os(Linux)
+  var allTests: [(String, () throws -> Void)] {
+    return [
+      ("testThatItCanResolveWithAutoWiring", testThatItCanResolveWithAutoWiring),
+      ("testThatItUsesAutoWireFactoryWithMostNumberOfArguments", testThatItUsesAutoWireFactoryWithMostNumberOfArguments),
+      ("testThatItThrowsAmbiguityErrorWhenUsingAutoWire", testThatItThrowsAmbiguityErrorWhenUsingAutoWire),
+      ("testThatItFirstTriesToUseTaggedFactoriesWhenUsingAutoWire", testThatItFirstTriesToUseTaggedFactoriesWhenUsingAutoWire),
+      ("testThatItFallbackToNotTaggedFactoryWhenUsingAutoWire", testThatItFallbackToNotTaggedFactoryWhenUsingAutoWire),
+      ("testThatItDoesNotTryToUseAutoWiringWhenCallingResolveWithArguments", testThatItDoesNotTryToUseAutoWiringWhenCallingResolveWithArguments),
+      ("testThatItDoesNotUseAutoWiringWhenFailedToResolveLowLevelDependency", testThatItDoesNotUseAutoWiringWhenFailedToResolveLowLevelDependency),
+      ("testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgain", testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgain),
+      ("testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithTheSameTagged", testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithTheSameTagged),
+      ("testThatItDoesNotReuseInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithNoTag", testThatItDoesNotReuseInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithNoTag)
+    ]
+  }
+
+  func setUp() {
+    container.reset()
+  }
+  #else
+  override func setUp() {
+    container.reset()
+  }
+  #endif
+
+  func testThatItCanResolveWithAutoWiring() {
+    //given
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(.ObjectGraph) { ServiceImp2() }
+    
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+    
+    //when
+    let client = try! container.resolve() as AutoWiredClient
+    
+    //then
+    let service1 = client.service1
+    XCTAssertTrue(service1 is ServiceImp1)
+    let service2 = client.service2
+    XCTAssertTrue(service2 is ServiceImp2)
+  }
+  
+  func testThatItUsesAutoWireFactoryWithMostNumberOfArguments() {
+    //given
+    
+    //1 arg
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
+    //1 arg
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: try self.container.resolve(), service2: $0) as AutoWiredClient }
+    
+    //2 args
+    var factoryWithMostNumberOfArgumentsCalled = false
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+      .resolveDependencies { _ in
+        factoryWithMostNumberOfArgumentsCalled = true
+    }
+    
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(.ObjectGraph) { ServiceImp2() }
+    
+    //when
+    let _ = try! container.resolve() as AutoWiredClient
+    
+    //then
+    XCTAssertTrue(factoryWithMostNumberOfArgumentsCalled)
+  }
+  
+  func testThatItThrowsAmbiguityErrorWhenUsingAutoWire() {
+    //given
+    
+    //1 arg
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
+    //1 arg
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: try self.container.resolve(), service2: $0) as AutoWiredClient }
+    
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(.ObjectGraph) { ServiceImp2() }
+    
+    //when
+    do {
+      try container.resolve() as AutoWiredClient
+      XCTFail("Container should throw error on ambiguous factories")
+    }
+      //then
+    catch let DipError.AmbiguousDefinitions(key) {
+      XCTAssertEqual(key.numberOfArguments, 1)
+    }
+    catch {
+      XCTFail("Thrown unexpected error")
+    }
+  }
+  
+  func testThatItFirstTriesToUseTaggedFactoriesWhenUsingAutoWire() {
+    //given
+    
+    //1 arg
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
+    //1 arg
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: try self.container.resolve(), service2: $0) as AutoWiredClient }
+    
+    //2 args
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+    
+    //1 arg tagged
+    var taggedFactoryWithMostNumberOfArgumentsCalled = false
+    container.register(tag: "tag", .ObjectGraph) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
+    
+    //2 arg tagged
+    container.register(tag: "tag", .ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }.resolveDependencies { _ in
+      taggedFactoryWithMostNumberOfArgumentsCalled = true
+    }
+
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(.ObjectGraph) { ServiceImp2() }
+    
+    //when
+    let _ = try! container.resolve(tag: "tag") as AutoWiredClient
+    
+    //then
+    XCTAssertTrue(taggedFactoryWithMostNumberOfArgumentsCalled)
+  }
+  
+  func testThatItFallbackToNotTaggedFactoryWhenUsingAutoWire() {
+    //given
+    
+    //1 arg
+    var notTaggedFactoryWithMostNumberOfArgumentsCalled = false
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }.resolveDependencies {_ in
+      notTaggedFactoryWithMostNumberOfArgumentsCalled = true
+    }
+    
+    //1 arg tagged
+    container.register(tag: "tag", .ObjectGraph) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
+    
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(.ObjectGraph) { ServiceImp2() }
+    
+    //when
+    let _ = try! container.resolve(tag: "other tag") as AutoWiredClient
+    
+    //then
+    XCTAssertTrue(notTaggedFactoryWithMostNumberOfArgumentsCalled)
+  }
+  
+  func testThatItDoesNotTryToUseAutoWiringWhenCallingResolveWithArguments() {
+    //given
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(.ObjectGraph) { ServiceImp2() }
+    
+    //when
+    let service = try! container.resolve() as Service
+    do {
+      try container.resolve(withArguments: service) as AutoWiredClient
+      XCTFail("Container should not use auto-wiring when resolving with runtime arguments")
+    }
+    catch {
+      //should fail as no definition with 1 argument was not registered
+    }
+  }
+  
+  func testThatItDoesNotUseAutoWiringWhenFailedToResolveLowLevelDependency() {
+    container.register(.ObjectGraph) { AutoWiredClientImp() as AutoWiredClient }
+      .resolveDependencies { container, resolved in
+        resolved.service1 = try container.resolve() as Service
+        resolved.service2 = try container.resolve() as ServiceImp2
+        
+        //simulate that something goes wrong on the way
+        throw DipError.DefinitionNotFound(key: DefinitionKey(protocolType: ServiceImp1.self, factoryType: Any.self))
+    }
+    
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+      .resolveDependencies { container, resolved in
+        //auto-wiring should be performed only when definition for type to resolve is not found
+        //but not for any other type along the way in the graph
+        XCTFail("Auto-wiring should not be performed if instance was actually resolved.")
+    }
+    
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(.ObjectGraph) { ServiceImp2() }
+    
+    do {
+      try container.resolve() as AutoWiredClient
+      XCTFail("Container should not use auto-wiring when definition for resolved type is registered.")
+    }
+    catch {
+      //should fail as there was an error while resolving object graph
+    }
+    
+  }
+  
+  func testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgain() {
+    
+    //given
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(.ObjectGraph) { ServiceImp2() }
+    
+    var anotherInstance: AutoWiredClient?
+    
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+      .resolveDependencies { container, _ in
+        if anotherInstance == nil {
+          anotherInstance = try! container.resolve() as AutoWiredClient
+        }
+    }
+    
+    //when
+    let resolved = try! container.resolve() as AutoWiredClient
+    
+    //then
+    //when doing another auto-wiring during resolve we should reuse instance
+    XCTAssertTrue((resolved as! AutoWiredClientImp) === (anotherInstance as! AutoWiredClientImp))
+  }
+  
+  func testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithTheSameTagged() {
+    
+    //given
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(.ObjectGraph) { ServiceImp2() }
+    
+    var anotherInstance: AutoWiredClient?
+    
+    container.register(tag: "tag", .ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+      .resolveDependencies { container, _ in
+        if anotherInstance == nil {
+          anotherInstance = try! container.resolve(tag: "tag") as AutoWiredClient
+        }
+    }
+    
+    //when
+    let resolved = try! container.resolve(tag: "tag") as AutoWiredClient
+    
+    //then
+    //when doing another auto-wiring during resolve we should reuse instance
+    XCTAssertTrue((resolved as! AutoWiredClientImp) === (anotherInstance as! AutoWiredClientImp))
+  }
+  
+  func testThatItDoesNotReuseInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithNoTag() {
+    
+    //given
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(.ObjectGraph) { ServiceImp2() }
+    
+    var anotherInstance: AutoWiredClient?
+    
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+      .resolveDependencies { container, _ in
+        if anotherInstance == nil {
+          anotherInstance = try! container.resolve() as AutoWiredClient
+        }
+    }
+    
+    //when
+    let resolved = try! container.resolve(tag: "tag") as AutoWiredClient
+    
+    //then
+    //when doing another auto-wiring during resolve we should reuse instance
+    XCTAssertTrue((resolved as! AutoWiredClientImp) !== (anotherInstance as! AutoWiredClientImp))
+  }
+  
+}
+

--- a/Dip/DipTests/Sources/AutoWiringTests.swift
+++ b/Dip/DipTests/Sources/AutoWiringTests.swift
@@ -133,8 +133,8 @@ class AutoWiringTests: XCTestCase {
       XCTFail("Container should throw error on ambiguous factories")
     }
       //then
-    catch let DipError.AmbiguousDefinitions(key) {
-      XCTAssertEqual(key.numberOfArguments, 1)
+    catch let DipError.AmbiguousDefinitions(_, numberOfArguments) {
+      XCTAssertEqual(numberOfArguments, 1)
     }
     catch {
       XCTFail("Thrown unexpected error")

--- a/Dip/DipTests/Sources/main.swift
+++ b/Dip/DipTests/Sources/main.swift
@@ -6,5 +6,6 @@ XCTMain([
   RuntimeArgumentsTests(), 
   ComponentScopeTests(),
   AutoInjectionTests(),
-  ThreadSafetyTests()
+  ThreadSafetyTests(),
+  AutoWiringTests()
 ])

--- a/DipPlayground.playground/Pages/Auto-wiring.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Auto-wiring.xcplaygroundpage/Contents.swift
@@ -1,0 +1,117 @@
+//: [Previous: Shared Instances](@previous)
+
+import Dip
+import UIKit
+
+/*:
+
+### Auto-wiring
+
+Among three main DI patterns - _constructor_, _property_ and _method_ injection - construction injection should be your choise by default. Dip makes use of this pattern very simple. 
+
+Let's say you have some VIPER module with following components:
+*/
+protocol Service {}
+protocol Interactor {
+    var service: Service { get }
+}
+protocol Router {}
+protocol ViewOutput {}
+protocol Presenter {
+    var router: Router { get }
+    var interactor: Interactor { get }
+    var view: ViewOutput { get }
+}
+
+class RouterImp: Router {}
+class View: UIView, ViewOutput {}
+class ServiceImp: Service {}
+
+/*:
+VIPER module by its nature consists of a lot of components, wired up using protocols. Using construction injection you can end up with following constructors for presenter and interactor:
+*/
+
+class InteractorImp: Interactor {
+    var service: Service
+    
+    init(service: Service) {
+        self.service = service
+    }
+}
+
+class PresenterImp: Presenter {
+    let router: Router
+    let interactor: Interactor
+    let view: ViewOutput
+    
+    init(view: ViewOutput, interactor: Interactor, router: Router) {
+        self.view = view
+        self.interactor = interactor
+        self.router = router
+    }
+}
+
+/*:
+If you register these components in a container you will end up with rather boilerplate code:
+*/
+
+let container = DependencyContainer()
+container.register { ServiceImp() as Service }
+container.register { RouterImp() as Router }
+container.register { View() as ViewOutput }
+
+container.register { try InteractorImp(service: container.resolve()) as Interactor }
+container.register {
+    try PresenterImp(
+        view: container.resolve(),
+        interactor: container.resolve(),
+        router: container.resolve()) as Presenter
+}
+
+
+var presenter = try! container.resolve() as Presenter
+presenter.interactor.service
+
+/*:
+While definition for `Interactor` looks fine, `Presenter`'s definition is overloaded with the same `resolve` calls to container.
+
+The other option you have is to register factory with runtime arguments:
+*/
+
+container.register { InteractorImp(service: $0) as Interactor }
+container.register { PresenterImp(view: $0, interactor: $1, router: $2) as Presenter }
+
+/*: 
+But then to resolve presenter or interactor you will first need to resolve their dependencies and pass them as arguments to `resolve` method:
+*/
+
+let service = try! container.resolve() as Service
+let interactor = try! container.resolve(withArguments: service) as Interactor
+let view = try! container.resolve() as ViewOutput
+let router = try! container.resolve() as Router
+presenter = try! container.resolve(withArguments: view, interactor, router) as Presenter
+presenter.interactor.service
+
+/*:
+Again to much of boilerplate code. Also it's easy to make a mistake in the order of arguments.
+
+Auto-wiring solves this problem by combining these two approaches - you register factories with runtime arguments, but resolve components with just a call to `resolve()`. Container will resolve all consturctor arguments for you.
+*/
+
+container.register { InteractorImp(service: $0) as Interactor }
+container.register { PresenterImp(view: $0, interactor: $1, router: $2) as Presenter }
+
+presenter = try! container.resolve() as Presenter
+presenter.interactor.service
+
+/*:
+You don't need to call `resolve` in a factory and care about order of arguments any more.
+
+The only requirement is that all constructor arguments should be registered in the container and there should be no several factories with the same _number_ of arguments registered for the same components. 
+
+In very rare case when you have several different factories with different set of runtime arguments registered for the same component, when you try to resolve it container will try to use these factories one by one until one of them succeeds starting with a factory with most numbers of arguments. If it finds two factories with the same number of arguments it will throw an error.
+
+You can use auto-wiring with tags. The tag that you pass to `resolve` method will be used to resolve each of the constructor arguments.
+*/
+
+//: [Next: Auto-injection](@next)

--- a/DipPlayground.playground/Pages/Auto-wiring.xcplaygroundpage/timeline.xctimeline
+++ b/DipPlayground.playground/Pages/Auto-wiring.xcplaygroundpage/timeline.xctimeline
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Timeline
+   version = "3.0">
+   <TimelineItems>
+   </TimelineItems>
+</Timeline>

--- a/DipPlayground.playground/Pages/Shared Instances.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Shared Instances.xcplaygroundpage/Contents.swift
@@ -158,6 +158,6 @@ If you want to know more about Dependency Injection in general we recomend you t
 
 */
 
-//: [Next: Auto-Injection](@next)
+//: [Next: Auto-wiring](@next)
 
 

--- a/DipPlayground.playground/contents.xcplayground
+++ b/DipPlayground.playground/contents.xcplayground
@@ -9,6 +9,7 @@
         <page name='Scopes'/>
         <page name='Circular dependencies'/>
         <page name='Shared Instances'/>
+        <page name='Auto-wiring'/>
         <page name='Auto-injection'/>
         <page name='Testing'/>
     </pages>

--- a/README.md
+++ b/README.md
@@ -205,9 +205,27 @@ container.register(.ObjectGraph) { ServerImp() as Server }
 ```
 More information about circular dependencies you can find in the Playground.
 
-### Auto-Injection
+### Auto-wiring
 
-Auto-injection lets your resolve all the dependencies of the instance resolved by container with just one call, also allowing a simpler syntax to register circular dependencies.
+When you use constructor injection to inject dependencies in your component auto-wiring enables you to resolve it just with one call to `resolve` method without carying about how to resolve all constructor arguments - container will resolve them for you.
+
+```swift
+class PresenterImp: Presenter {
+    init(view: ViewOutput, interactor: Interactor, router: Router) { ... }
+    ...
+}
+
+container.register { RouterImp() as Router }
+container.register { View() as ViewOutput }
+container.register { InteractorImp() as Interactor }
+container.register { PresenterImp(view: $0, interactor: $1, router: $2) as Presenter }
+
+let presenter = try! container.resolve() as Presenter
+```
+
+### Auto-injection
+
+Auto-injection lets your resolve all property dependencies of the instance resolved by container with just one call, also allowing a simpler syntax to register circular dependencies.
 
 ```swift
 protocol Server {

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -156,8 +156,8 @@ extension DependencyContainer {
    Though before you do so you should probably review your design and try to reduce number of depnedencies.
    */
   public func registerFactory<T, F>(tag tag: Tag? = nil, scope: ComponentScope, factory: F, numberOfArguments: Int, autoWiringFactory: (DependencyContainer, Tag?) throws -> T) -> DefinitionOf<T, F> {
-    let definition = DefinitionOf<T, F>(scope: scope, factory: factory, autoWiringFactory: autoWiringFactory)
-    register(definition, forTag: tag, numberOfArguments: numberOfArguments)
+    let definition = DefinitionOf<T, F>(scope: scope, factory: factory, autoWiringFactory: autoWiringFactory, numberOfArguments: numberOfArguments)
+    register(definition, forTag: tag)
     return definition
   }
 
@@ -170,9 +170,8 @@ extension DependencyContainer {
       - definition: The definition to register in the container.
    
    */
-  public func register<T, F>(definition: DefinitionOf<T, F>, forTag tag: Tag? = nil, numberOfArguments: Int? = nil) {
-    var key = DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: tag)
-    key.numberOfArguments = numberOfArguments
+  public func register<T, F>(definition: DefinitionOf<T, F>, forTag tag: Tag? = nil) {
+    let key = DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: tag)
     register(definition, forKey: key)
   }
   
@@ -465,7 +464,7 @@ public enum DipError: ErrorType, CustomStringConvertible {
   */
   case AutoInjectionFailed(label: String?, type: Any.Type, underlyingError: ErrorType)
 
-  case AmbiguousDefinitions(DefinitionKey)
+  case AmbiguousDefinitions(DefinitionKey, Int)
   
   public var description: String {
     switch self {
@@ -475,8 +474,8 @@ public enum DipError: ErrorType, CustomStringConvertible {
       return "No definition registered for \(key).\nCheck the tag, type you try to resolve, number, order and types of runtime arguments passed to `resolve()` and match them with registered factories for type \(key.protocolType)."
     case let .AutoInjectionFailed(label, type, error):
       return "Failed to auto-inject property \"\(label.desc)\" of type \(type). \(error)"
-    case let .AmbiguousDefinitions(key):
-      return "Ambiguous definitions for \(key.protocolType) with factories that accept the same number of runtime arguments (\(key.numberOfArguments.desc))."
+    case let .AmbiguousDefinitions(key, numberOfArguments):
+      return "Ambiguous definitions for \(key.protocolType) with factories that accept the same number of runtime arguments (\(numberOfArguments))."
     }
   }
 }

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -100,7 +100,29 @@ extension DependencyContainer {
     return definition
   }
   
-  @available(*, deprecated=4.3.0, message="Use registerFactory<T, F>(tag:scope:factory:numberOfArguments:autoWiringFactory:")
+  /**
+   Register generic factory associated with an optional tag.
+   
+   - parameters:
+      - tag: The arbitrary tag to associate this factory with. Pass `nil` to associate with any tag. Default value is `nil`.
+      - scope: The scope to use for instance created by the factory.
+      - factory: The factory to register.
+   
+   - returns: A registered definition.
+   
+   - note: You _should not_ call this method directly, instead call any of other `register` methods.
+   You _should_ use this method only to register dependency with more runtime arguments
+   than _Dip_ supports (currently it's up to six) like in the following example:
+   
+   ```swift
+   public func register<T, Arg1, Arg2, Arg3, ...>(tag: Tag? = nil, scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, ...) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, ...) throws -> T> {
+     return registerFactory(tag: tag, scope: scope, factory: factory)
+   }
+   ```
+   
+   Though before you do so you should probably review your design and try to reduce number of depnedencies.
+   */
+  @available(*, deprecated=4.3.0, message="Use registerFactory(tag:scope:factory:numberOfArguments:autoWiringFactory:) instead.")
   public func registerFactory<T, F>(tag tag: Tag? = nil, scope: ComponentScope, factory: F) -> DefinitionOf<T, F> {
     let definition = DefinitionOf<T, F>(scope: scope, factory: factory)
     register(definition, forTag: tag)
@@ -108,14 +130,14 @@ extension DependencyContainer {
   }
 
   /**
-   Register generic factory associated with an optional tag.
+   Register generic factory and auto-wiring factory and associate it with an optional tag.
    
    - parameters:
-   - tag: The arbitrary tag to associate this factory with. Pass `nil` to associate with any tag. Default value is `nil`.
-   - scope: The scope to use for instance created by the factory.
-   - factory: The factory to register.
-   - numberOfArguments: The number of factory arguments.
-   - autoWiringFactory: The factory that uses container to resolve all its arguments.
+      - tag: The arbitrary tag to associate this factory with. Pass `nil` to associate with any tag. Default value is `nil`.
+      - scope: The scope to use for instance created by the factory.
+      - factory: The factory to register.
+      - numberOfArguments: The number of factory arguments. Will be used on auto-wiring to sort definitions.
+      - autoWiringFactory: The factory to be used on auto-wiring to resolve component.
    
    - returns: A registered definition.
    

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -94,37 +94,51 @@ extension DependencyContainer {
    ```
    */
   public func register<T>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: () throws -> T) -> DefinitionOf<T, () throws -> T> {
-    return registerFactory(tag: tag, scope: scope, factory: factory)
-  }
-  
-  /**
-   Register generic factory associated with an optional tag.
-   
-   - parameters:
-      - tag: The arbitrary tag to associate this factory with. Pass `nil` to associate with any tag. Default value is `nil`.
-      - scope: The scope to use for instance created by the factory.
-      - factory: The factory to register.
-   
-   - returns: A registered definition.
-
-   - note: You _should not_ call this method directly, instead call any of other `register` methods.
-           You _should_ use this method only to register dependency with more runtime arguments
-           than _Dip_ supports (currently it's up to six) like in the following example:
-   
-   ```swift
-   public func register<T, Arg1, Arg2, Arg3, ...>(tag: Tag? = nil, scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, ...) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, ...) throws -> T> {
-     return registerFactory(tag: tag, scope: scope, factory: factory) as DefinitionOf<T, (Arg1, Arg2, Arg3, ...) throws -> T>
-   }
-   ```
-   
-   Though before you do so you should probably review your design and try to reduce number of depnedencies.
-   */
-  public func registerFactory<T, F>(tag tag: Tag? = nil, scope: ComponentScope, factory: F) -> DefinitionOf<T, F> {
+    typealias F = () throws -> T
     let definition = DefinitionOf<T, F>(scope: scope, factory: factory)
     register(definition, forTag: tag)
     return definition
   }
   
+  @available(*, deprecated=4.3.0, message="Use registerFactory<T, F>(tag:scope:factory:numberOfArguments:autoWiringFactory:")
+  public func registerFactory<T, F>(tag tag: Tag? = nil, scope: ComponentScope, factory: F) -> DefinitionOf<T, F> {
+    let definition = DefinitionOf<T, F>(scope: scope, factory: factory)
+    register(definition, forTag: tag)
+    return definition
+  }
+
+  /**
+   Register generic factory associated with an optional tag.
+   
+   - parameters:
+   - tag: The arbitrary tag to associate this factory with. Pass `nil` to associate with any tag. Default value is `nil`.
+   - scope: The scope to use for instance created by the factory.
+   - factory: The factory to register.
+   - numberOfArguments: The number of factory arguments.
+   - autoWiringFactory: The factory that uses container to resolve all its arguments.
+   
+   - returns: A registered definition.
+   
+   - note: You _should not_ call this method directly, instead call any of other `register` methods.
+   You _should_ use this method only to register dependency with more runtime arguments
+   than _Dip_ supports (currently it's up to six) like in the following example:
+   
+   ```swift
+   public func register<T, Arg1, Arg2, Arg3, ...>(tag: Tag? = nil, scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, ...) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, ...) throws -> T> {
+     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: ...) { container, tag in
+        try factory(try container.resolve(tag: tag), ...)
+      }
+   }
+   ```
+   
+   Though before you do so you should probably review your design and try to reduce number of depnedencies.
+   */
+  public func registerFactory<T, F>(tag tag: Tag? = nil, scope: ComponentScope, factory: F, numberOfArguments: Int, autoWiringFactory: (DependencyContainer, Tag?) throws -> T) -> DefinitionOf<T, F> {
+    let definition = DefinitionOf<T, F>(scope: scope, factory: factory, autoWiringFactory: autoWiringFactory)
+    register(definition, forTag: tag, numberOfArguments: numberOfArguments)
+    return definition
+  }
+
   /**
    Register definiton in the container and associate it with an optional tag.
    Will override already registered definition for the same type and factory, associated with the same tag.
@@ -134,8 +148,9 @@ extension DependencyContainer {
       - definition: The definition to register in the container.
    
    */
-  public func register<T, F>(definition: DefinitionOf<T, F>, forTag tag: Tag? = nil) {
-    let key = DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: tag)
+  public func register<T, F>(definition: DefinitionOf<T, F>, forTag tag: Tag? = nil, numberOfArguments: Int? = nil) {
+    var key = DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: tag)
+    key.numberOfArguments = numberOfArguments
     register(definition, forKey: key)
   }
   
@@ -210,40 +225,52 @@ extension DependencyContainer {
    */
   public func resolve<T, F>(tag tag: Tag? = nil, builder: F throws -> T) throws -> T {
     let key = DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: tag)
-
+    
     do {
-      return try _resolveKey(key, builder: builder)
+      //first we try to find defintion that exactly matches parameters
+      return try _resolveKey(key, builder: { definition throws -> T in
+        guard let factory = definition._factory as? F else {
+          throw DipError.DefinitionNotFound(key: key)
+        }
+        return try builder(factory)
+      })
     }
     catch {
       switch error {
       case let DipError.DefinitionNotFound(errorKey) where key == errorKey:
-        throw error
+        //then if no definition found we try atuo-wiring
+        return try threadSafe {
+          guard let resolved: T = try _resolveByAutoWiring(key) else {
+            throw error
+          }
+          return resolved
+        }
       default:
         throw DipError.ResolutionFailed(key: key, underlyingError: error)
       }
     }
   }
-  
-  /// Lookup definition by the key and use it to resolve instance. Fallback to the key with `nil` tag.
-  func _resolveKey<T, F>(key: DefinitionKey, builder: F throws -> T) throws -> T {
-    return try threadSafe {
-      let nilTagKey = key.associatedTag.map { _ in DefinitionKey(protocolType: T.self, factoryType: F.self, associatedTag: nil) }
 
-      guard let definition = (self.definitions[key] ?? self.definitions[nilTagKey]) as? DefinitionOf<T, F> else {
+  /// Lookup definition by the key and use it to resolve instance. Fallback to the key with `nil` tag.
+  func _resolveKey<T>(key: DefinitionKey, builder: _Definition throws -> T) throws -> T {
+    return try threadSafe {
+      let nilTagKey = key.associatedTag.map { _ in DefinitionKey(protocolType: T.self, factoryType: key.factoryType, associatedTag: nil) }
+
+      guard let definition = (self.definitions[key] ?? self.definitions[nilTagKey]) as? _Definition else {
         throw DipError.DefinitionNotFound(key: key)
       }
-      return try self._resolveDefinition(definition, key: key, builder: builder)
+      return try self._resolveDefinition(definition, usingKey: key, builder: builder)
     }
   }
   
   /// Actually resolve dependency.
-  private func _resolveDefinition<T, F>(definition: DefinitionOf<T, F>, key: DefinitionKey, builder: F throws -> T) rethrows -> T {
+  private func _resolveDefinition<T>(definition: _Definition, usingKey key: DefinitionKey, builder: _Definition throws -> T) rethrows -> T {
     return try resolvedInstances.resolve {
       if let previouslyResolved: T = resolvedInstances.previouslyResolvedInstance(forKey: key, inScope: definition.scope) {
         return previouslyResolved
       }
       else {
-        let resolvedInstance = try builder(definition.factory)
+        let resolvedInstance = try builder(definition)
         
         //when builder calls factory it will in turn resolve sub-dependencies (if there are any)
         //when it returns instance that we try to resolve here can be already resolved
@@ -415,6 +442,8 @@ public enum DipError: ErrorType, CustomStringConvertible {
       - underlyingError: The error that caused auto-injection to fail
   */
   case AutoInjectionFailed(label: String?, type: Any.Type, underlyingError: ErrorType)
+
+  case AmbiguousDefinitions(DefinitionKey)
   
   public var description: String {
     switch self {
@@ -424,6 +453,8 @@ public enum DipError: ErrorType, CustomStringConvertible {
       return "No definition registered for \(key).\nCheck the tag, type you try to resolve, number, order and types of runtime arguments passed to `resolve()` and match them with registered factories for type \(key.protocolType)."
     case let .AutoInjectionFailed(label, type, error):
       return "Failed to auto-inject property \"\(label.desc)\" of type \(type). \(error)"
+    case let .AmbiguousDefinitions(key):
+      return "Ambiguous definitions for \(key.protocolType) with factories that accept the same number of runtime arguments (\(key.numberOfArguments.desc))."
     }
   }
 }

--- a/Sources/RuntimeArguments.swift
+++ b/Sources/RuntimeArguments.swift
@@ -49,6 +49,8 @@ extension DependencyContainer {
   /**
    Resolve a dependency using one runtime argument.
    
+   - note: When resolving type container will first try to use definition that matches types of arguments that you pass to resolve method. If it fails or no such definition is found container will try to _auto-wire_ component. For that it will iterate through all the definitions registered for that type which factories accept any number of runtime arguments and are tagged with the same tag, passed to `resolve` method, or with no tag. Container will try to use these definitions to resolve a component one by one until one of them succeeds, starting with tagged definitions in order of decreasing their's factories number of arguments.
+   
    - parameters:
       - tag: The arbitrary tag to lookup registered definition.
       - arg1: The first argument to pass to the definition's factory.

--- a/Sources/RuntimeArguments.swift
+++ b/Sources/RuntimeArguments.swift
@@ -43,7 +43,7 @@ extension DependencyContainer {
   - seealso: `registerFactory(tag:scope:factory:)`
   */
   public func register<T, Arg1>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1) throws -> T) -> DefinitionOf<T, (Arg1) throws -> T> {
-    return registerFactory(tag: tag, scope: scope, factory: factory)
+    return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 1) { container, tag in try factory(try container.resolve(tag: tag)) }
   }
   
   /**
@@ -69,7 +69,7 @@ extension DependencyContainer {
   
   /// - seealso: `register(tag:scope:factory:)`
   public func register<T, Arg1, Arg2>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2) throws -> T) -> DefinitionOf<T, (Arg1, Arg2) throws -> T> {
-    return registerFactory(tag: tag, scope: scope, factory: factory)
+    return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 2) { container, tag in try factory(try container.resolve(tag: tag), try container.resolve(tag: tag)) }
   }
   
   /// - seealso: `resolve(tag:_:)`
@@ -81,7 +81,7 @@ extension DependencyContainer {
   
   /// - seealso: `register(tag:scope:factory:)`
   public func register<T, Arg1, Arg2, Arg3>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3) throws -> T> {
-    return registerFactory(tag: tag, scope: scope, factory: factory)
+    return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 3)  { container, tag in try factory(try container.resolve(tag: tag), try container.resolve(), try container.resolve(tag: tag)) }
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
@@ -93,7 +93,7 @@ extension DependencyContainer {
   
   /// - seealso: `register(tag:scope:factory:)`
   public func register<T, Arg1, Arg2, Arg3, Arg4>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4) throws -> T> {
-    return registerFactory(tag: tag, scope: scope, factory: factory)
+    return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 4) { container, tag in try factory(try container.resolve(tag: tag), try container.resolve(tag: tag), try container.resolve(tag: tag), try container.resolve(tag: tag)) }
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
@@ -105,7 +105,7 @@ extension DependencyContainer {
   
   /// - seealso: `register(tag:scope:factory:)`
   public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4, Arg5) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4, Arg5) throws -> T> {
-    return registerFactory(tag: tag, scope: scope, factory: factory)
+    return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 5) { container, tag in try factory(try container.resolve(tag: tag), try container.resolve(tag: tag), try container.resolve(tag: tag), try container.resolve(tag: tag), try container.resolve(tag: tag)) }
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
@@ -117,7 +117,7 @@ extension DependencyContainer {
   
   /// - seealso: `register(tag:scope:factory:)`
   public func register<T, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(tag tag: Tag? = nil, _ scope: ComponentScope = .Prototype, factory: (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) throws -> T) -> DefinitionOf<T, (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) throws -> T> {
-    return registerFactory(tag: tag, scope: scope, factory: factory)
+    return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 6) { container, tag in try factory(try container.resolve(tag: tag), try container.resolve(tag: tag), try container.resolve(tag: tag), try container.resolve(tag: tag), try container.resolve(tag: tag), try container.resolve(tag: tag)) }
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
@@ -126,3 +126,4 @@ extension DependencyContainer {
   }
 
 }
+


### PR DESCRIPTION
## What is auto-wiring?

Strictly speaking and comparing with other platforms (like .Net), this implementation is not exactly auto-wiring, but I can not come up with a better alternative. In (some) .Net containers auto-wiring is a container's feature to automatically resolve component as concrete type if all the arguments of it's default constructor are also concrete types without ever registering them. This implementation is different because it does not require concrete types and requires explicit registration.

## What it does?

Auto-wiring enables easier registration/resolution eliminating boilerplate repetitive calls to container.
With auto-wiring users can instead of this code:
```swift
container.register { RepositoryImp() as Repository }
container.register { ServiceImp(repository: try container.resolve()) as Service }
let service = try! container.resolve() as Service
```
or this:
```swift
container.register { RepositoryImp() as Repository }
container.register { ServiceImp(repository: $0) as Service }

let repository = try! container.resolve() as Repository
let service = try! container.resolve(withArguments: repository) as Service
```

do the same simply with this code:
```swift
container.register { RepositoryImp() as Repository }
container.register { ServiceImp(repository: $0) as Service }
let service = try! container.resolve() as Service
```
The difference is more clear when there are more constructor arguments.

## What is good?

Auto-wiring removes calls to container to resolve constructor arguments. For each argument, if it is also an abstraction and registered in container, this call will be the same. More arguments - more repetition removed. When registering component with dependencies container knows everything about them (their types and numbers) to be able to automatically resolve them and pass to the factory. That will work only when _all_ arguments types are registered in container and if `resolve` is called without runtime arguments.

It's not a breaking change. If user uses up to 6 arguments he will get auto-wiring out of the box. If user extended number of arguments resolution will still work the same way, and user can add auto-wiring feature with slight code change.

## What is bad?

From implementation side it requires making some APIs (interanal)  a bit less type safe. But as far as registration is controlled by container and not exposed to the user (at least when it comes to associated between `DefinitionKey` and `DefinitionOf`) it will be still safe. From usage point it can create confusion for new users because it will be possible to resolve component both using auto-wiring (with just `resolve()` call) and by passing arguments to `resolve(withArguments:)`, and it can be unclear that container will resolve arguments by itself. But I would prefer to consider auto-wiring a default way (even thought from implementation point it's in opposite a fallback route) to register/resolve components.

@AliSoftware If you are ok with that feature I will add a playground page and docs in this PR

## Implementation notes: 
To be able to "auto-wire" constructor dependencies I use separate factory (`autoWiringFactory`), created at the moment of registering "normal" factory, and number of it's arguments. When user calls `resolve` but no definition without runtime arguments was registered, instead of failing right away I start to iterate through all other definitions registered for the same type that accept any arguments (from most number of arguments to least) and try to use them to resolve a component until one of them succeeds. If all of them fail - only then component resolution is considered failed.