### PR TITLE
Added Resolvable protocol

### DIFF
--- a/Dip/DipTests/Sources/DipTests.swift
+++ b/Dip/DipTests/Sources/DipTests.swift
@@ -217,6 +217,26 @@ class DipTests: XCTestCase {
     }
   }
 
+  func testThatItCallsDidResolveDependenciesOnResolvableIntance() {
+    
+    class ResolvableService: Service, Resolvable {
+      var didResolveDependenciesCalled = false
+      
+      func didResolveDependencies() {
+        didResolveDependenciesCalled = true
+      }
+    }
+    
+    container.register { ResolvableService() as Service }
+      .resolveDependencies { _, service in
+        XCTAssertFalse((service as! ResolvableService).didResolveDependenciesCalled)
+        return
+    }
+    
+    let service = try! container.resolve() as Service
+    XCTAssertTrue((service as! ResolvableService).didResolveDependenciesCalled)
+  }
+  
 }
 
 

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -255,10 +255,8 @@ extension DependencyContainer {
         resolvedInstances.storeResolvedInstance(resolvedInstance, forKey: key, inScope: definition.scope)
         
         try definition.resolveDependenciesOf(resolvedInstance, withContainer: self)
-        
-        //we perform auto-injection as the last step to be able to reuse instances
-        //stored when manually resolving dependencies in resolveDependencies block
         try autoInjectProperties(resolvedInstance)
+        (resolvedInstance as? Resolvable)?.didResolveDependencies()
         
         return resolvedInstance
       }
@@ -382,6 +380,12 @@ public func ==(lhs: DependencyContainer.Tag, rhs: DependencyContainer.Tag) -> Bo
   default:
     return false
   }
+}
+
+/// Conform to this protocol when you need to have a callback when all the dependencies are injected.
+public protocol Resolvable {
+  /// This method is called by the container when all dependencies of the instance are resolved.
+  func didResolveDependencies()
 }
 
 /**


### PR DESCRIPTION
Resolves #56 

+/-:
+: separation of component definition from it's dependencies usage;
+: we currently perform auto-injections after calling `resolveDependencies` block, so even at the end of `resolveDependencies` block some of the dependencies could be not yet resolved. Actually the order of these two operations does not change anything functionality-wise, but changes what instances would be reused - auto-injected or resolved manually;
-: Conformance to `Resolvable` protocol introduces dependency on Dip.