### PR TITLE
EagerSingleton scope and bootstrap method

### DIFF
--- a/Sources/AutoInjection.swift
+++ b/Sources/AutoInjection.swift
@@ -49,6 +49,7 @@ extension DependencyContainer {
  instead of using `Injected<T>` or `InjectedWeak<T>` types.
  
  **Example**:
+ 
  ```swift
  class MyCustomBox<T> {
    private(set) var value: T?
@@ -75,7 +76,7 @@ public protocol AutoInjectedPropertyBox: class {
    
    - parameter container: A container to be used to resolve an instance
    
-  -note: This method is not intended to be called manually, `DependencyContainer` will call it by itself.
+  - note: This method is not intended to be called manually, `DependencyContainer` will call it by itself.
    */
   func resolve(container: DependencyContainer) throws
 }
@@ -93,7 +94,6 @@ public protocol AutoInjectedPropertyBox: class {
  class ClientImp: Client {
    var service = Injected<Service>()
  }
-
  ```
  - seealso: `InjectedWeak`
 

--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -131,6 +131,11 @@ public enum ComponentScope {
    ```
    */
   case Singleton
+  
+  /**
+   The same scope as `Singleton`, but instance will be created when container is bootstrapped.
+  */
+  case EagerSingleton
 }
 
 /**


### PR DESCRIPTION
Resolves #63 

New scope `EagerSingleton` lets users to register components that should be instantiated by container early in the app life cycle. To define this moment new method `bootstrap` was added to `DependencyContainer`, as was suggested by @sebastian-zarzycki-es. Method call is optional. But we can print warning in `resolve` method if it is called without calling bootstrap and warn that this method can become required in future versions. 
After bootstrap is called no modifications in registered definitions can be done (no removes, no adds). 

Obvious limitation of that approach is that it can only instantiate components using factories without runtime arguments. Should not be a serious issue though. And auto-wiring is still possible. If eager singleton has dependencies or somehow causes other singletons to be instantiated they also will be instantiated on bootstrap, even if they were not registered as eager singletons.