### PR TITLE
[WIP] Type forwarding and resolving optionals

### DIFF
--- a/Dip/DipTests/Sources/AutoWiringTests.swift
+++ b/Dip/DipTests/Sources/AutoWiringTests.swift
@@ -97,6 +97,30 @@ class AutoWiringTests: XCTestCase {
     XCTAssertTrue(anyClient is AutoWiredClientImp)
   }
   
+  func testThatItUsesTagToResolveDependenciesWithAutoWiring() {
+    //given
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(tag: "tag", .ObjectGraph) { ServiceImp2() as Service }
+    container.register(.ObjectGraph) { ServiceImp2() }
+    
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+    
+    //when
+    let client = try! container.resolve(tag: "tag") as AutoWiredClient
+    
+    //then
+    let service1 = client.service1
+    XCTAssertTrue(service1 is ServiceImp2)
+    let service2 = client.service2
+    XCTAssertTrue(service2 is ServiceImp2)
+    
+    //when
+    let anyClient = try! container.resolve(AutoWiredClient.self)
+    
+    //then
+    XCTAssertTrue(anyClient is AutoWiredClientImp)
+  }
+  
   func testThatItUsesAutoWireFactoryWithMostNumberOfArguments() {
     //given
     

--- a/Dip/DipTests/Sources/AutoWiringTests.swift
+++ b/Dip/DipTests/Sources/AutoWiringTests.swift
@@ -38,7 +38,7 @@ private class AutoWiredClientImp: AutoWiredClient {
   var service1: Service!
   var service2: Service!
   
-  init(service1: Service, service2: ServiceImp2) {
+  init(service1: Service?, service2: ServiceImp2) {
     self.service1 = service1
     self.service2 = service2
   }
@@ -279,7 +279,7 @@ class AutoWiringTests: XCTestCase {
     XCTAssertTrue((resolved as! AutoWiredClientImp) === (anotherInstance as! AutoWiredClientImp))
   }
   
-  func testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithTheSameTagged() {
+  func testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithTheSameTag() {
     
     //given
     container.register(.ObjectGraph) { ServiceImp1() as Service }

--- a/Dip/DipTests/Sources/DefinitionTests.swift
+++ b/Dip/DipTests/Sources/DefinitionTests.swift
@@ -112,5 +112,18 @@ class DefinitionTests: XCTestCase {
     //then
     XCTAssertFalse(blockCalled)
   }
+  
+  func testThatItRegisteresOptionalTypesAsForwardedTypes() {
+    let def = DefinitionOf<Service, () -> Service>(scope: .Prototype) { ServiceImp() as Service }
+      .implements(NSObject.self)
+    
+    XCTAssertTrue(def.implementingTypes.contains({ $0 == Service?.self }))
+    XCTAssertTrue(def.implementingTypes.contains({ $0 == Service!.self }))
+    
+    XCTAssertTrue(def.implementingTypes.contains({ $0 == NSObject.self }))
+    XCTAssertTrue(def.implementingTypes.contains({ $0 == NSObject?.self }))
+    XCTAssertTrue(def.implementingTypes.contains({ $0 == NSObject!.self }))
+  }
+  
 }
 

--- a/Dip/DipTests/Sources/DipTests.swift
+++ b/Dip/DipTests/Sources/DipTests.swift
@@ -91,6 +91,12 @@ class DipTests: XCTestCase {
     
     //then
     XCTAssertTrue(serviceInstance is ServiceImp1)
+
+    //and when
+    let anyService = try! container.resolve(Service.self, tag: "service")
+    
+    //then
+    XCTAssertTrue(anyService is ServiceImp1)
   }
   
   func testThatItResolvesDifferentInstancesRegisteredForDifferentTags() {
@@ -105,6 +111,14 @@ class DipTests: XCTestCase {
     //then
     XCTAssertTrue(service1Instance is ServiceImp1)
     XCTAssertTrue(service2Instance is ServiceImp2)
+    
+    //when
+    let anyService1 = try! container.resolve(Service.self, tag: "service1")
+    let anyService2 = try! container.resolve(Service.self, tag: "service2")
+    
+    //then
+    XCTAssertTrue(anyService1 is ServiceImp1)
+    XCTAssertTrue(anyService2 is ServiceImp2)
   }
   
   func testThatNewRegistrationOverridesPreviousRegistration() {
@@ -133,6 +147,13 @@ class DipTests: XCTestCase {
     
     //then
     XCTAssertTrue(resolveDependenciesCalled)
+    resolveDependenciesCalled = false
+    
+    //and when
+    try! container.resolve(Service.self)
+    
+    //then
+    XCTAssertTrue(resolveDependenciesCalled)
   }
   
   func testThatItThrowsErrorIfCanNotFindDefinitionForType() {
@@ -149,6 +170,17 @@ class DipTests: XCTestCase {
 
       return true
     }
+
+    //and when
+    AssertThrows(expression: try container.resolve(Service.self)) { error in
+      guard case let DipError.DefinitionNotFound(key) = error else { return false }
+      
+      //then
+      let expectedKey = DefinitionKey(protocolType: Service.self, argumentsType: Void.self, associatedTag: nil)
+      XCTAssertEqual(key, expectedKey)
+      
+      return true
+    }
   }
   
   func testThatItThrowsErrorIfCanNotFindDefinitionForTag() {
@@ -157,6 +189,17 @@ class DipTests: XCTestCase {
     
     //when
     AssertThrows(expression: try container.resolve(tag: "other tag") as Service) { error in
+      guard case let DipError.DefinitionNotFound(key) = error else { return false }
+      
+      //then
+      let expectedKey = DefinitionKey(protocolType: Service.self, argumentsType: Void.self, associatedTag: "other tag")
+      XCTAssertEqual(key, expectedKey)
+      
+      return true
+    }
+
+    //and when
+    AssertThrows(expression: try container.resolve(Service.self, tag: "other tag")) { error in
       guard case let DipError.DefinitionNotFound(key) = error else { return false }
       
       //then
@@ -181,6 +224,17 @@ class DipTests: XCTestCase {
 
       return true
     }
+
+    //and when
+    AssertThrows(expression: try container.resolve(Service.self, withArguments: "some string")) { error in
+      guard case let DipError.DefinitionNotFound(key) = error else { return false }
+      
+      //then
+      let expectedKey = DefinitionKey(protocolType: Service.self, argumentsType: String.self, associatedTag: nil)
+      XCTAssertEqual(key, expectedKey)
+      
+      return true
+    }
   }
   
   func testThatItThrowsErrorIfConstructorThrows() {
@@ -191,6 +245,14 @@ class DipTests: XCTestCase {
     
     //when
     AssertThrows(expression: try container.resolve() as Service) { error in
+      switch error {
+      case let DipError.DefinitionNotFound(key) where key == failedKey: return true
+      default: return false
+      }
+    }
+    
+    //and when
+    AssertThrows(expression: try container.resolve(Service.self)) { error in
       switch error {
       case let DipError.DefinitionNotFound(key) where key == failedKey: return true
       default: return false
@@ -210,6 +272,14 @@ class DipTests: XCTestCase {
     
     //when
     AssertThrows(expression: try container.resolve() as Service) { error in
+      switch error {
+      case let DipError.DefinitionNotFound(key) where key == failedKey: return true
+      default: return false
+      }
+    }
+    
+    //and when
+    AssertThrows(expression: try container.resolve(Service.self)) { error in
       switch error {
       case let DipError.DefinitionNotFound(key) where key == failedKey: return true
       default: return false

--- a/Sources/AutoWiring.swift
+++ b/Sources/AutoWiring.swift
@@ -25,10 +25,11 @@
 extension DependencyContainer {
   
   /// Tries to resolve instance using auto-wire factories
-  func _resolveByAutoWiring(key: DefinitionKey, type: Any.Type) throws -> Any? {
+  func _resolveByAutoWiring(key: DefinitionKey) throws -> Any? {
     guard key.argumentsType == Void.self else { return nil }
     
     let tag = key.associatedTag
+    let type = key.protocolType
     let autoWiringDefinitions = self.autoWiringDefinitionsFor(type, tag: tag)
     return try _resolveEnumeratingKeys(autoWiringDefinitions) { try _resolveKey($0, tag: tag, type: type) }
   }

--- a/Sources/AutoWiring.swift
+++ b/Sources/AutoWiring.swift
@@ -35,13 +35,11 @@ extension DependencyContainer {
   }
 
   private func autoWiringDefinitionsFor(type: Any.Type, tag: DependencyContainer.Tag?) -> [(DefinitionKey, _Definition)] {
-    var definitions = self.definitions
-      .map({ ($0.0, $0.1) })
+    var definitions = self.definitions.map({ ($0.0, $0.1) })
     
     //filter definitions
-    definitions =  definitions
-      .filter({ $0.1.supportsAutoWiring() })
-      .filter({ $0.0.protocolType == type })
+    definitions = definitions.filter({ $0.1.supportsAutoWiring() })
+      .filter({ $0.0.protocolType == type || $0.1.implementingTypes.contains({ $0 == type }) })
       .filter({ $0.0.associatedTag == tag || $0.0.associatedTag == nil })
     
     //order definitions
@@ -78,9 +76,9 @@ extension DependencyContainer {
   private func _resolveKey(key: DefinitionKey, tag: DependencyContainer.Tag?, type: Any.Type) throws -> Any? {
     let key = DefinitionKey(protocolType: key.protocolType, argumentsType: key.argumentsType, associatedTag: tag)
     
-    return try _resolveKey(key, builder: { definition throws -> Any in
+    return try _resolveKey(key, builder: { definition in
       try definition.autoWiringFactory!(self, tag)
-    })
+    }) as Any
   }
   
 }

--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -291,7 +291,6 @@ public protocol Definition: class { }
 protocol _Definition: Definition {
   var scope: ComponentScope { get }
 
-  var baseFactory: Any { get }
   var weakFactory: (Any throws -> Any)! { get }
 
   var numberOfArguments: Int { get }
@@ -308,9 +307,6 @@ extension _Definition {
 }
 
 extension DefinitionOf: _Definition {
-  var baseFactory: Any {
-    return factory
-  }
 }
 
 extension DefinitionOf: CustomStringConvertible {
@@ -340,7 +336,8 @@ class DefinitionBuilder<T, U> {
     definition.autoWiringFactory = autoWiringFactory
     definition.weakFactory = {
       guard let args = $0 as? U else {
-        fatalError("Internal inconsistency exception! Expected arguments: \(U.self); passed arguments:\($0); Definition: \(definition)")
+        let key = DefinitionKey(protocolType: T.self, argumentsType: U.self)
+        throw DipError.DefinitionNotFound(key: key)
       }
       return try factory(args)
     }

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -40,8 +40,8 @@ public final class DependencyContainer {
   }
   
   var definitions = [DefinitionKey : _Definition]()
-  let resolvedInstances = ResolvedInstances()
-  let lock = RecursiveLock()
+  private let resolvedInstances = ResolvedInstances()
+  private let lock = RecursiveLock()
   
   private(set) var bootstrapped = false
   private var bootstrapQueue: [() throws -> ()] = []
@@ -121,38 +121,6 @@ extension DependencyContainer {
     return definition
   }
   
-  /**
-   Register generic factory associated with an optional tag.
-   
-   - parameters:
-      - tag: The arbitrary tag to associate this factory with. Pass `nil` to associate with any tag. Default value is `nil`.
-      - scope: The scope to use for instance created by the factory.
-      - factory: The factory to register.
-   
-   - returns: A registered definition.
-   
-   - note: You _should not_ call this method directly, instead call any of other `register` methods.
-   You _should_ use this method only to register dependency with more runtime arguments
-   than _Dip_ supports (currently it's up to six) like in the following example:
-   
-   ```swift
-   public func register<T, A, B, C, ...>(tag: Tag? = nil, scope: ComponentScope = .Prototype, factory: (A, B, C, ...) throws -> T) -> DefinitionOf<T, (A, B, C, ...) throws -> T> {
-     return registerFactory(tag: tag, scope: scope, factory: factory)
-   }
-   ```
-   
-   Though before you do so you should probably review your design and try to reduce number of depnedencies.
-   */
-  @available(*, deprecated=4.3.0, message="Use registerFactory(tag:scope:factory:numberOfArguments:autoWiringFactory:) instead.")
-  public func registerFactory<T, U>(tag tag: DependencyTagConvertible? = nil, scope: ComponentScope, factory: U throws -> T) -> DefinitionOf<T, U throws -> T> {
-    let definition = DefinitionBuilder<T, U> {
-      $0.scope = scope
-      $0.factory = factory
-    }.build()
-    register(definition, forTag: tag)
-    return definition
-  }
-
   /**
    Register generic factory and auto-wiring factory and associate it with an optional tag.
    
@@ -249,6 +217,10 @@ extension DependencyContainer {
     return try resolve(tag: tag) { (factory: () throws -> T) in try factory() }
   }
   
+  public func resolve(type: Any.Type, tag: DependencyTagConvertible? = nil) throws -> Any {
+    return try self.resolve(type, tag: tag) { factory in try factory(())}
+  }
+
   /**
    Resolve an instance of type `T` using generic builder closure that accepts generic factory and returns created instance.
    
@@ -274,42 +246,43 @@ extension DependencyContainer {
    Though before you do so you should probably review your design and try to reduce the number of dependencies.
    */
   public func resolve<T, U>(tag tag: DependencyTagConvertible? = nil, builder: (U throws -> T) throws -> T) throws -> T {
-    let key = DefinitionKey(protocolType: T.self, argumentsType: U.self, associatedTag: tag?.dependencyTag)
-
-    do {
-      //first we try to find defintion that exactly matches parameters
-      return try _resolveKey(key, builder: { definition throws -> T in
-        typealias F = U throws -> T
-        guard let factory = definition.baseFactory as? F else {
+    let resolved = try resolve(T.self, tag: tag, builder: { (factory: (U throws -> Any)) in
+      try builder({
+        guard let resolved = try factory($0) as? T else {
+          let key = DefinitionKey(protocolType: T.self, argumentsType: U.self, associatedTag: tag?.dependencyTag)
           throw DipError.DefinitionNotFound(key: key)
         }
-        return try builder(factory)
+        return resolved
       })
-    }
-    catch {
-      guard let resolved = try _autoWireOrRethrow(key, type: T.self, error: error) as? T else {
-        throw error
-      }
-      return resolved
-    }
+    })
+    
+    return resolved as! T
+  }
+  
+  public func resolve<U>(type: Any.Type, tag: DependencyTagConvertible? = nil, builder: (U throws -> Any) throws -> Any) throws -> Any {
+    let key = DefinitionKey(protocolType: type, argumentsType: U.self, associatedTag: tag?.dependencyTag)
+    
+    return try _resolveKey(key, builder: { definition throws -> Any in
+      try builder(definition.weakFactory)
+    })
   }
   
   /// Lookup definition by the key and use it to resolve instance. Fallback to the key with `nil` tag.
   func _resolveKey<T>(key: DefinitionKey, builder: _Definition throws -> T) throws -> T {
     return try threadSafe {
-      let nilTagKey = key.associatedTag.map { _ in
-        DefinitionKey(protocolType: key.protocolType, argumentsType: key.argumentsType, associatedTag: nil)
+      guard let (definition, matchingKey) = matchDefinition(key) else {
+        let error = DipError.DefinitionNotFound(key: key)
+        guard let resolved = try _resolveByAutoWiring(key) as? T else {
+          throw error
+        }
+        return resolved
       }
-
-      guard let definition = (self.definitions[key] ?? self.definitions[nilTagKey]) else {
-        throw DipError.DefinitionNotFound(key: key)
-      }
-      return try self._resolveDefinition(definition, usingKey: key, builder: builder)
+      return try self._resolveDefinition(definition, forKey: matchingKey, builder: builder)
     }
   }
   
   /// Actually resolve dependency.
-  private func _resolveDefinition<T>(definition: _Definition, usingKey key: DefinitionKey, builder: _Definition throws -> T) rethrows -> T {
+  private func _resolveDefinition<T>(definition: _Definition, forKey key: DefinitionKey, builder: _Definition throws -> T) rethrows -> T {
     return try resolvedInstances.resolve {
       if let previouslyResolved: T = resolvedInstances.previouslyResolvedInstance(forKey: key, inScope: definition.scope) {
         return previouslyResolved
@@ -334,99 +307,16 @@ extension DependencyContainer {
     }
   }
   
-  ///Pool to hold instances, created during call to `resolve()`.
-  ///Before `resolve()` returns pool is drained.
-  class ResolvedInstances {
-    var resolvedInstances = [DefinitionKey: Any]()
-    var singletons = [DefinitionKey: Any]()
-    var resolvableInstances = [Resolvable]()
-
-    func storeResolvedInstance<T>(instance: T, forKey key: DefinitionKey, inScope scope: ComponentScope) {
-      switch scope {
-      case .Singleton, .EagerSingleton: singletons[key] = instance
-      case .ObjectGraph: resolvedInstances[key] = instance
-      case .Prototype: break
-      }
-      
-      if let resolvable = instance as? Resolvable {
-        resolvableInstances.append(resolvable)
-      }
+  private func matchDefinition(key: DefinitionKey) -> (_Definition, DefinitionKey)? {
+    let nilTagKey = key.associatedTag.map { _ in
+      DefinitionKey(protocolType: key.protocolType, argumentsType: key.argumentsType, associatedTag: nil)
     }
     
-    func previouslyResolvedInstance<T>(forKey key: DefinitionKey, inScope scope: ComponentScope) -> T? {
-      switch scope {
-      case .Singleton, .EagerSingleton: return singletons[key] as? T
-      case .ObjectGraph: return resolvedInstances[key] as? T
-      case .Prototype: return nil
-      }
+    if let definition = (self.definitions[key] ?? self.definitions[nilTagKey]) {
+      return (definition, key)
     }
     
-    private var depth: Int = 0
-    
-    func resolve<T>(@noescape block: () throws ->T) rethrows -> T {
-      depth = depth + 1
-      
-      defer {
-        depth = depth - 1
-        if depth == 0 {
-          // We call didResolveDependencies only at this point
-          // because this is a point when dependencies graph is complete.
-          for resolvedInstance in resolvableInstances.reverse() {
-            resolvedInstance.didResolveDependencies()
-          }
-          resolvedInstances.removeAll()
-          resolvableInstances.removeAll()
-        }
-      }
-      
-      let resolved = try block()
-      return resolved
-    }
-  }
-  
-}
-
-//MARK: - Auto-wiring
-
-extension DependencyContainer {
-  
-  private func _autoWireOrRethrow(key: DefinitionKey, type: Any.Type, error: ErrorType) throws -> Any? {
-    switch error {
-    case let DipError.DefinitionNotFound(errorKey) where key == errorKey:
-      //if no definition found for key that we were trying to resolve - try atuo-wiring
-      return try threadSafe {
-        guard let resolved = try _resolveByAutoWiring(key, type: type) else {
-          throw error
-        }
-        return resolved
-      }
-    default:
-      throw error
-    }
-  }
-
-}
-
-//MARK: - Weakly typed resolve
-
-extension DependencyContainer {
-  
-  public func resolve(type: Any.Type, tag: DependencyTagConvertible? = nil) throws -> Any {
-    return try self.resolve(type, tag: tag) { factory in try factory(())}
-  }
-  
-  public func resolve<U>(type: Any.Type, tag: DependencyTagConvertible? = nil, builder: (U throws -> Any) throws -> Any) throws -> Any {
-    let key = DefinitionKey(protocolType: type, argumentsType: U.self, associatedTag: tag?.dependencyTag)
-    
-    do {
-      //first we try to find defintion that exactly matches parameters
-      return try _resolveKey(key, builder: { definition throws -> Any in
-        try builder(definition.weakFactory)
-      })
-    }
-    catch {
-      return try _autoWireOrRethrow(key, type: type, error: error)
-    }
+    return nil
   }
   
 }
@@ -467,6 +357,56 @@ extension DependencyContainer {
     }
   }
 
+}
+
+///Pool to hold instances, created during call to `resolve()`.
+///Before `resolve()` returns pool is drained.
+private class ResolvedInstances {
+  var resolvedInstances = [DefinitionKey: Any]()
+  var singletons = [DefinitionKey: Any]()
+  var resolvableInstances = [Resolvable]()
+  
+  func storeResolvedInstance<T>(instance: T, forKey key: DefinitionKey, inScope scope: ComponentScope) {
+    switch scope {
+    case .Singleton, .EagerSingleton: singletons[key] = instance
+    case .ObjectGraph: resolvedInstances[key] = instance
+    case .Prototype: break
+    }
+    
+    if let resolvable = instance as? Resolvable {
+      resolvableInstances.append(resolvable)
+    }
+  }
+  
+  func previouslyResolvedInstance<T>(forKey key: DefinitionKey, inScope scope: ComponentScope) -> T? {
+    switch scope {
+    case .Singleton, .EagerSingleton: return singletons[key] as? T
+    case .ObjectGraph: return resolvedInstances[key] as? T
+    case .Prototype: return nil
+    }
+  }
+  
+  private var depth: Int = 0
+  
+  func resolve<T>(@noescape block: () throws ->T) rethrows -> T {
+    depth = depth + 1
+    
+    defer {
+      depth = depth - 1
+      if depth == 0 {
+        // We call didResolveDependencies only at this point
+        // because this is a point when dependencies graph is complete.
+        for resolvedInstance in resolvableInstances.reverse() {
+          resolvedInstance.didResolveDependencies()
+        }
+        resolvedInstances.removeAll()
+        resolvableInstances.removeAll()
+      }
+    }
+    
+    let resolved = try block()
+    return resolved
+  }
 }
 
 extension DependencyContainer: CustomStringConvertible {
@@ -603,5 +543,19 @@ public enum DipError: ErrorType, CustomStringConvertible {
       return "Ambiguous definitions for \(type):\n" +
       definitions.map({ "\($0)" }).joinWithSeparator(";\n")
     }
+  }
+}
+
+//MARK: - Deprecated methods
+
+extension DependencyContainer {
+  @available(*, deprecated=4.3.0, message="Use registerFactory(tag:scope:factory:numberOfArguments:autoWiringFactory:) instead.")
+  public func registerFactory<T, U>(tag tag: DependencyTagConvertible? = nil, scope: ComponentScope, factory: U throws -> T) -> DefinitionOf<T, U throws -> T> {
+    let definition = DefinitionBuilder<T, U> {
+      $0.scope = scope
+      $0.factory = factory
+      }.build()
+    register(definition, forTag: tag)
+    return definition
   }
 }

--- a/Sources/RuntimeArguments.swift
+++ b/Sources/RuntimeArguments.swift
@@ -47,9 +47,18 @@ extension DependencyContainer {
   }
   
   /**
-   Resolve a dependency using one runtime argument.
+   Resolve type `T` using one runtime argument.
    
-   - note: When resolving type container will first try to use definition that matches types of arguments that you pass to resolve method. If it fails or no such definition is found container will try to _auto-wire_ component. For that it will iterate through all the definitions registered for that type which factories accept any number of runtime arguments and are tagged with the same tag, passed to `resolve` method, or with no tag. Container will try to use these definitions to resolve a component one by one until one of them succeeds, starting with tagged definitions in order of decreasing their's factories number of arguments.
+   - note: When resolving a type container will first try to use definition 
+           that exactly matches types of arguments that you pass to resolve method. 
+           If it fails or no such definition is found container will try to _auto-wire_ component. 
+           For that it will iterate through all the definitions registered for that type
+           which factories accept any number of runtime arguments and are tagged with the same tag,
+           passed to `resolve` method, or with no tag. Container will try to use these definitions
+           to resolve a component one by one until one of them succeeds, starting with tagged definitions
+           in order of decreasing their's factories number of arguments. If none of them succeds it will
+           throw an error. If it finds two definitions with the same number of arguments - it will throw
+           an error.
    
    - parameters:
       - tag: The arbitrary tag to lookup registered definition.
@@ -65,6 +74,7 @@ extension DependencyContainer {
     return try resolve(tag: tag) { factory in try factory(arg1) }
   }
 
+  ///- seealso: `resolve(_:tag:)`, `resolve(tag:withArguments:)`
   public func resolve<A>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A) throws -> Any {
     return try resolve(type, tag: tag) { factory in try factory(arg1) }
   }
@@ -76,11 +86,12 @@ extension DependencyContainer {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 2) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   
-  /// - seealso: `resolve(tag:_:)`
+  /// - seealso: `resolve(tag:withArguments:)`
   public func resolve<T, A, B>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B) throws -> T {
     return try resolve(tag: tag) { factory in try factory(arg1, arg2) }
   }
   
+  ///- seealso: `resolve(_:tag:)`, `resolve(tag:withArguments:)`
   public func resolve<A, B>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B) throws -> Any {
     return try resolve(type, tag: tag) { factory in try factory((arg1, arg2)) }
   }
@@ -97,6 +108,7 @@ extension DependencyContainer {
     return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3) }
   }
   
+  ///- seealso: `resolve(_:tag:)`, `resolve(tag:withArguments:)`
   public func resolve<A, B, C>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C) throws -> Any {
     return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3)) }
   }
@@ -113,6 +125,7 @@ extension DependencyContainer {
     return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3, arg4) }
   }
 
+  ///- seealso: `resolve(_:tag:)`, `resolve(tag:withArguments:)`
   public func resolve<A, B, C, D>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D) throws -> Any {
     return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3, arg4)) }
   }
@@ -129,6 +142,7 @@ extension DependencyContainer {
     return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3, arg4, arg5) }
   }
 
+  ///- seealso: `resolve(_:tag:)`, `resolve(tag:withArguments:)`
   public func resolve<A, B, C, D, E>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E) throws -> Any {
     return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3, arg4, arg5)) }
   }
@@ -145,6 +159,7 @@ extension DependencyContainer {
     return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3, arg4, arg5, arg6) }
   }
 
+  ///- seealso: `resolve(_:tag:)`, `resolve(tag:withArguments:)`
   public func resolve<A, B, C, D, E, F>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E, _ arg6: F) throws -> Any {
     return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3, arg4, arg5, arg6)) }
   }


### PR DESCRIPTION
### Type forwarding
Sometimes we have situations when some component implements several protocols (provides several services). If we want to reuse the same instance for different services in the same object graph we had to do it manually, like this:

```swift
container.register { try ServiceImp(client: container.resolve()) as Service }
  .resolveDependencies { container, service in
    service.delegate = service.client as! ServiceDelegate
}
container.register { ClientImp() as Client }
```

or hack it around with this:

```swift
container.register { try ServiceImp(client: container.resolve()) as Service }
  .resolveDependencies { container, service in
    service.delegate = try container.resolve() as ServiceDelegate
}
container.register(.ObjectGraph) { ClientImp() as Client }
container.register { (try container.resolve() as Client) as! ServiceDelegate }
````

With type-forwarding we can register the same definition for several types and reuse produced instance in the same object graph:

```swift
container.register { try ServiceImp(client: container.resolve()) as Service }
  .resolveDependencies { container, service in
    service.delegate = container.resolve() as ServiceDelegate
}
container.register(.ObjectGraph) { ClientImp() as Client }
  .implements(ServiceDelegate.self)
```

This way we make our registrations more flexible, because later we can easily change definition for `ServiceDelegate` from `ClientImp` to something else without changing definition of service.

### Resolving optionals
Type forwarding also lets us easily resolve optional types. With type inference it is very easy to make a following mistake:

```swift
class Service {
  init(client: Client?)
}

container.register { ClientImp() as Client }

container.register { try ServiceImp(client: container.resolve()) as Service }
//or with auto-wiring
container.register { ServiceImp(client: $0) as Service }

//this will fail because container will try to resolve inferred `Client?` type which is not the same as `Client`
try! container.resolve() as Service
```

One way to solve the problem is to always specify type to resolve:

```swift
container.register { try ServiceImp(client: container.resolve() as Client) as Service }
container.register { ServiceImp(client: $0 as Client) as Service }
```

But that is easy to forget. With type forwarding Dip becomes smart enough to make it work. Under the hood  it implicitly registers optional types as forwarded types so no additional actions are required from the user.

```swift
container.register { try ServiceImp(client: container.resolve()) as Service }
//or with auto-wiring
container.register { ServiceImp(client: $0) as Service }

//will successfully resolve client
try! container.resolve() as Service
```
With that providing explicit types of dependencies in configurations becomes almost unneeded.

But it does not solve the problem of runtime arguments:

```swift
container.register { client in ServiceImp(url: client) as Service }

let client: Client = ...

//this will still fail because container registered `(Client?) throws -> Service` factory but will try to lookup `(Client) throws -> Service`
try! container.resolve(withArguments: client) as Service

let optClient: Client? = ...
//this will work
try! container.resolve(withArguments: optClient) as Service
```

#### Drawbacks:
- there is no way to ensure type-safety of `implements` method. If produced by definition instance does not implement forwarded type container will throw error
- if there are several definitions for different types registered with the same (or nil) tags and they both forward to the same type, container will throw error when resolving forwarded type because there is no way to select one of the definitions (without relying on internal implementation details of swift dictionary keys sorting).
- forwarded types will not override existing definitions for the same types and vice versa, what is different from standard registration behavior