### PR TITLE
[WIP] Pass tag to auto-injected propertiies

### DIFF
--- a/Dip/DipTests/Sources/AutoInjectionTests.swift
+++ b/Dip/DipTests/Sources/AutoInjectionTests.swift
@@ -293,6 +293,44 @@ class AutoInjectionTests: XCTestCase {
     
     //server and tagged server should be resolved as different instances
     XCTAssertTrue(server !== taggedServer)
+    XCTAssertNotNil(server)
+    XCTAssertNotNil(taggedServer)
+  }
+  
+  func testThatItPassesTagToAutoInjectedProperty() {
+    //given
+    container.register(.ObjectGraph) { ServerImp() as Server }
+    container.register(tag: "tagged", .ObjectGraph) { ServerImp() as Server }
+    container.register(.ObjectGraph) { ClientImp() as Client }
+    
+    //when
+    let client = try! container.resolve(tag: "tagged") as Client
+    
+    //then
+    let taggedServer = (client as! ClientImp).taggedServer.value!
+    let server = client.server!
+    
+    //server and tagged server should be resolved as the same instance
+    XCTAssertTrue(server === taggedServer)
+  }
+  
+  func testThatItDoesNotPassTagToAutoInjectedPropertyWithExplicitTag() {
+    //given
+    container.register(.ObjectGraph) { ServerImp() as Server }
+    container.register(tag: "tagged", .ObjectGraph) { ServerImp() as Server }
+    container.register(.ObjectGraph) { ClientImp() as Client }
+    
+    //when
+    let client = try! container.resolve(tag: "otherTag") as Client
+    
+    //then
+    let taggedServer = (client as! ClientImp).taggedServer.value!
+    let server = client.server!
+    
+    //server and tagged server should be resolved as different instances
+    XCTAssertTrue(server !== taggedServer)
+    XCTAssertNotNil(server)
+    XCTAssertNotNil(taggedServer)
   }
   
 }

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -327,7 +327,7 @@ extension DependencyContainer {
         resolvedInstances.storeResolvedInstance(resolvedInstance, forKey: key, inScope: definition.scope)
         
         try definition.resolveDependenciesOf(resolvedInstance, withContainer: self)
-        try autoInjectProperties(resolvedInstance)
+        try autoInjectProperties(resolvedInstance, tag: key.associatedTag)
         
         return resolvedInstance
       }


### PR DESCRIPTION
When auto-injecting properties we can pass tag used to resolve containing instance to provide a context and to be able to use tagged definition to resolve injected property. The same way tag is passed through to resolve dependencies with auto-wiring. If injected property is defined with explicit tag it will be used instead.