### PR TITLE
Container context

### DIFF
--- a/Dip/Dip.xcodeproj/project.pbxproj
+++ b/Dip/Dip.xcodeproj/project.pbxproj
@@ -62,6 +62,9 @@
 		09D598331C6F9EC100F24D49 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D598321C6F9EC100F24D49 /* Utils.swift */; };
 		09D598341C6F9EC100F24D49 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D598321C6F9EC100F24D49 /* Utils.swift */; };
 		09D598351C6F9EC100F24D49 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D598321C6F9EC100F24D49 /* Utils.swift */; };
+		64EC9B511CD0CB4000FF6A4C /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64EC9B501CD0CB4000FF6A4C /* ContextTests.swift */; };
+		64EC9B521CD0CBB400FF6A4C /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64EC9B501CD0CB4000FF6A4C /* ContextTests.swift */; };
+		64EC9B531CD0CBB500FF6A4C /* ContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64EC9B501CD0CB4000FF6A4C /* ContextTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -113,6 +116,7 @@
 		09B035FF1C5D2B83001EA5B7 /* AutoWiring.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AutoWiring.swift; path = ../../Sources/AutoWiring.swift; sourceTree = "<group>"; };
 		09C20EBF1C8B3BC3009A082B /* ThreadSafetyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ThreadSafetyTests.swift; path = Sources/ThreadSafetyTests.swift; sourceTree = "<group>"; };
 		09D598321C6F9EC100F24D49 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Utils.swift; path = Sources/Utils.swift; sourceTree = "<group>"; };
+		64EC9B501CD0CB4000FF6A4C /* ContextTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -190,6 +194,7 @@
 			isa = PBXGroup;
 			children = (
 				0919F4D01C16417000DC3B10 /* DipTests.swift */,
+				64EC9B501CD0CB4000FF6A4C /* ContextTests.swift */,
 				0919F4CF1C16417000DC3B10 /* DefinitionTests.swift */,
 				0919F4D21C16417000DC3B10 /* RuntimeArgumentsTests.swift */,
 				0919F4CE1C16417000DC3B10 /* ComponentScopeTests.swift */,
@@ -525,6 +530,7 @@
 				0919F4E31C16419300DC3B10 /* DipTests.swift in Sources */,
 				0919F4E51C16419300DC3B10 /* RuntimeArgumentsTests.swift in Sources */,
 				09873F771C1E024E000C02F6 /* AutoInjectionTests.swift in Sources */,
+				64EC9B511CD0CB4000FF6A4C /* ContextTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -553,6 +559,7 @@
 				0919F4E71C16419400DC3B10 /* DipTests.swift in Sources */,
 				0919F4E91C16419400DC3B10 /* RuntimeArgumentsTests.swift in Sources */,
 				09873F781C1E024E000C02F6 /* AutoInjectionTests.swift in Sources */,
+				64EC9B521CD0CBB400FF6A4C /* ContextTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -581,6 +588,7 @@
 				0919F4EB1C16419500DC3B10 /* DipTests.swift in Sources */,
 				0919F4ED1C16419500DC3B10 /* RuntimeArgumentsTests.swift in Sources */,
 				09873F791C1E024F000C02F6 /* AutoInjectionTests.swift in Sources */,
+				64EC9B531CD0CBB500FF6A4C /* ContextTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Dip/DipTests/ContextTests.swift
+++ b/Dip/DipTests/ContextTests.swift
@@ -1,0 +1,222 @@
+//
+// Dip
+//
+// Copyright (c) 2015 Olivier Halligon <olivier@halligon.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import XCTest
+@testable import Dip
+
+private protocol Service {}
+private class ServiceImp1: Service {
+  let injected = Injected<ServiceImp2>()
+  let injectedWeak = InjectedWeak<ServiceImp2>()
+  let taggedInjected = Injected<ServiceImp2>(tag: "injectedTag")
+  let taggedInjectedWeak = InjectedWeak<ServiceImp2>(tag: "injectedTag")
+  let injectedNilTag = Injected<ServiceImp2>(tag: nil)
+}
+private class ServiceImp2: Service {}
+
+class ContextTests: XCTestCase {
+
+  let container = DependencyContainer()
+  
+  #if os(Linux)
+  var allTests: [(String, () throws -> Void)] {
+    return [
+      ("testThatContextStoresCurrentlyResolvedType", testThatContextStoresCurrentlyResolvedType),
+      ("testThatContextStoresInjectedInType", testThatContextStoresInjectedInType),
+      ("testThatContextStoresTheTagPassedToResolve", testThatContextStoresTheTagPassedToResolve),
+      ("testThatContextStoresTheTagPassedToResolveWhenAutoInjecting", testThatContextStoresTheTagPassedToResolveWhenAutoInjecting),
+      ("testThatContextStoresTheTagPassedToResolveWhenAutoWiring", testThatContextStoresTheTagPassedToResolveWhenAutoWiring),
+      ("testThatContextDoesNotOverrideNilTagPassedToResolve", testThatContextDoesNotOverrideNilTagPassedToResolve),
+      ("testThatContextStoresNameOfAutoInjectedProperty", testThatContextStoresNameOfAutoInjectedProperty)
+    ]
+  }
+  
+  func setUp() {
+    container.reset()
+  }
+  #else
+  override func setUp() {
+    container.reset()
+    container.register { ServiceImp2() }
+  }
+  #endif
+
+  func testThatContextStoresCurrentlyResolvedType() {
+    container.register { () -> Service in
+      XCTAssertTrue(self.container.context.resolvingType == Service.self)
+      let _ = try self.container.resolve() as ServiceImp1
+      return ServiceImp1() as Service
+      }.resolveDependencies { _ in
+        XCTAssertTrue(self.container.context.resolvingType == Service.self)
+        let _ = try self.container.resolve() as ServiceImp1
+    }
+    
+    container.register { () -> ServiceImp1 in
+      XCTAssertTrue(self.container.context.resolvingType == ServiceImp1.self)
+      return ServiceImp1()
+      }.resolveDependencies { _ in
+        XCTAssertTrue(self.container.context.resolvingType == ServiceImp1.self)
+    }
+    
+    let _ = try! container.resolve() as Service
+  }
+  
+  func testThatContextStoresInjectedInType() {
+    container.register { () -> Service in
+      XCTAssertNil(self.container.context.injectedInType)
+      let _ = try self.container.resolve() as ServiceImp1
+      return ServiceImp1() as Service
+      }.resolveDependencies { _ in
+        XCTAssertNil(self.container.context.injectedInType)
+        let _ = try self.container.resolve() as ServiceImp1
+    }
+    
+    container.register { () -> ServiceImp1 in
+      XCTAssertTrue(self.container.context.injectedInType == Service.self)
+      return ServiceImp1()
+      }.resolveDependencies { _ in
+        XCTAssertTrue(self.container.context.injectedInType == Service.self)
+    }
+    
+    let _ = try! container.resolve() as Service
+  }
+
+  func testThatContextStoresTheTagPassedToResolve() {
+    container.register { () -> Service in
+      XCTAssertNotNil(self.container.context.tag)
+      XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
+      let _ = try self.container.resolve(tag: "otherTag") as ServiceImp1
+      return ServiceImp1() as Service
+      }.resolveDependencies { _ in
+        XCTAssertNotNil(self.container.context.tag)
+        XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
+        let _ = try self.container.resolve(tag: "otherTag") as ServiceImp1
+    }
+    
+    container.register { () -> ServiceImp1 in
+      XCTAssertNotNil(self.container.context.tag)
+      XCTAssertTrue(DependencyContainer.Tag.String("otherTag") ~= self.container.context.tag!)
+      return ServiceImp1()
+      }.resolveDependencies { _ in
+        XCTAssertNotNil(self.container.context.tag)
+        XCTAssertTrue(DependencyContainer.Tag.String("otherTag") ~= self.container.context.tag!)
+    }
+    
+    let _ = try! container.resolve(tag: "tag") as Service
+  }
+  
+  func testThatContextStoresTheTagPassedToResolveWhenAutoInjecting() {
+    container.register { ServiceImp1() as Service }
+    container.register { ServiceImp1() }
+    
+    container.register() { () -> ServiceImp2 in
+      if self.container.context.injectedInProperty == "injectedNilTag" {
+        XCTAssertNil(self.container.context.tag)
+      }
+      else {
+        XCTAssertNotNil(self.container.context.tag)
+        XCTAssertTrue(DependencyContainer.Tag.String("injectedTag") ~= self.container.context.tag!)
+      }
+      return ServiceImp2()
+      }.resolveDependencies { _ in
+        if self.container.context.injectedInProperty == "injectedNilTag" {
+          XCTAssertNil(self.container.context.tag)
+        }
+        else {
+          XCTAssertNotNil(self.container.context.tag)
+          XCTAssertTrue(DependencyContainer.Tag.String("injectedTag") ~= self.container.context.tag!)
+        }
+    }
+    
+    container.register(tag: "tag") { () -> ServiceImp2 in
+      XCTAssertNotNil(self.container.context.tag)
+      XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
+      return ServiceImp2()
+      }.resolveDependencies { _ in
+        XCTAssertNotNil(self.container.context.tag)
+        XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
+    }
+    
+    let _ = try! container.resolve(tag: "tag") as Service
+  }
+
+  func testThatContextStoresTheTagPassedToResolveWhenAutoWiring() {
+    container.register { (_: ServiceImp1) -> Service in
+      return ServiceImp1() as Service
+      }.resolveDependencies { _ in
+    }
+    
+    container.register { () -> ServiceImp1 in
+      XCTAssertNotNil(self.container.context.tag)
+      XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
+      return ServiceImp1()
+      }.resolveDependencies { _ in
+        XCTAssertNotNil(self.container.context.tag)
+        XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
+    }
+    
+    let _ = try! container.resolve(tag: "tag") as Service
+  }
+
+  func testThatContextDoesNotOverrideNilTagPassedToResolve() {
+    container.register { () -> Service in
+      XCTAssertNotNil(self.container.context.tag)
+      XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
+      let _ = try self.container.resolve() as ServiceImp1
+      return ServiceImp1() as Service
+      }.resolveDependencies { _ in
+        XCTAssertNotNil(self.container.context.tag)
+        XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
+        let _ = try self.container.resolve() as ServiceImp1
+    }
+    
+    container.register { () -> ServiceImp1 in
+      XCTAssertNil(self.container.context.tag)
+      return ServiceImp1()
+      }.resolveDependencies { _ in
+        XCTAssertNil(self.container.context.tag)
+    }
+    
+    let _ = try! container.resolve(tag: "tag") as Service
+  }
+  
+  func testThatContextStoresNameOfAutoInjectedProperty() {
+    container.register { ServiceImp1() as Service }
+    container.register { ServiceImp1() }
+    
+    let names = ["injected", "injectedWeak", "taggedInjected", "taggedInjectedWeak", "injectedNilTag"]
+    
+    container.register() { () -> ServiceImp2 in
+      XCTAssertNotNil(self.container.context.injectedInProperty)
+      XCTAssertTrue(names.contains(self.container.context.injectedInProperty!))
+      return ServiceImp2()
+      }.resolveDependencies { _ in
+        XCTAssertNotNil(self.container.context.injectedInProperty)
+        XCTAssertTrue(names.contains(self.container.context.injectedInProperty!))
+    }
+    
+    let _ = try! container.resolve() as Service
+  }
+  
+}

--- a/Dip/DipTests/Sources/AutoInjectionTests.swift
+++ b/Dip/DipTests/Sources/AutoInjectionTests.swift
@@ -63,6 +63,7 @@ private class ClientImp: Client {
   var _optionalProperty = Injected<AnyObject>(required: false)
   
   var taggedServer = Injected<Server>(tag: "tagged")
+  var nilTaggedServer = Injected<Server>(tag: nil)
 }
 
 private class Obj1 {
@@ -103,7 +104,9 @@ class AutoInjectionTests: XCTestCase {
       ("testThatThereIsNoRetainCycleBetweenAutoInjectedCircularDependencies", testThatThereIsNoRetainCycleBetweenAutoInjectedCircularDependencies),
       ("testThatItCallsDidInjectOnAutoInjectedProperty", testThatItCallsDidInjectOnAutoInjectedProperty),
       ("testThatNoErrorThrownWhenOptionalPropertiesAreNotAutoInjected", testThatNoErrorThrownWhenOptionalPropertiesAreNotAutoInjected),
-      ("testThatItResolvesTaggedAutoInjectedProperties", testThatItResolvesTaggedAutoInjectedProperties)
+      ("testThatItResolvesTaggedAutoInjectedProperties", testThatItResolvesTaggedAutoInjectedProperties),
+      ("testThatItPassesTagToAutoInjectedProperty", testThatItPassesTagToAutoInjectedProperty),
+      ("testThatItDoesNotPassTagToAutoInjectedPropertyWithExplicitTag", testThatItDoesNotPassTagToAutoInjectedPropertyWithExplicitTag)
     ]
   }
 
@@ -293,6 +296,52 @@ class AutoInjectionTests: XCTestCase {
     
     //server and tagged server should be resolved as different instances
     XCTAssertTrue(server !== taggedServer)
+    XCTAssertNotNil(server)
+    XCTAssertNotNil(taggedServer)
+  }
+  
+  func testThatItPassesTagToAutoInjectedProperty() {
+    //given
+    container.register(.ObjectGraph) { ServerImp() as Server }
+    container.register(tag: "tagged", .ObjectGraph) { ServerImp() as Server }
+    container.register(.ObjectGraph) { ClientImp() as Client }
+    
+    //when
+    let client = try! container.resolve(tag: "tagged") as Client
+    
+    //then
+    let taggedServer = (client as! ClientImp).taggedServer.value!
+    let server = client.server!
+    
+    //server and tagged server should be resolved as the same instance
+    XCTAssertTrue(server === taggedServer)
+  }
+  
+  func testThatItDoesNotPassTagToAutoInjectedPropertyWithExplicitTag() {
+    //given
+    container.register(.ObjectGraph) { ServerImp() as Server }
+    container.register(tag: "tagged", .ObjectGraph) { ServerImp() as Server }
+
+    container.register(.ObjectGraph) { ClientImp() as Client }
+      .resolveDependencies { (container, client) -> () in
+        client.anotherServer = try! container.resolve() as Server
+    }
+
+    //when
+    let client = try! container.resolve(tag: "otherTag") as Client
+    
+    //then
+    let taggedServer = (client as! ClientImp).taggedServer.value!
+    let nilTaggedServer = (client as! ClientImp).nilTaggedServer.value!
+    let server = client.server!
+    
+    //server and tagged server should be resolved as different instances
+    XCTAssertTrue(server !== taggedServer)
+    XCTAssertTrue((client.anotherServer as! ServerImp) === nilTaggedServer)
+    
+    XCTAssertNotNil(server)
+    XCTAssertNotNil(taggedServer)
+    XCTAssertNotNil(nilTaggedServer)
   }
   
 }

--- a/Dip/DipTests/Sources/AutoWiringTests.swift
+++ b/Dip/DipTests/Sources/AutoWiringTests.swift
@@ -28,6 +28,7 @@ import XCTest
 private protocol Service: class { }
 private class ServiceImp1: Service { }
 private class ServiceImp2: Service { }
+private class ServiceImp3 {}
 
 private protocol AutoWiredClient: class {
   var service1: Service! { get set }
@@ -61,7 +62,13 @@ class AutoWiringTests: XCTestCase {
       ("testThatItDoesNotUseAutoWiringWhenFailedToResolveLowLevelDependency", testThatItDoesNotUseAutoWiringWhenFailedToResolveLowLevelDependency),
       ("testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgain", testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgain),
       ("testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithTheSameTagged", testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithTheSameTagged),
-      ("testThatItDoesNotReuseInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithNoTag", testThatItDoesNotReuseInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithNoTag)
+      ("testThatItDoesNotReuseInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithNoTag", testThatItDoesNotReuseInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithNoTag),
+      ("testThatItUsesTagToResolveDependenciesWithAutoWiringWith1Argument", testThatItUsesTagToResolveDependenciesWithAutoWiringWith1Argument),
+      ("testThatItUsesTagToResolveDependenciesWithAutoWiringWith2Argument", testThatItUsesTagToResolveDependenciesWithAutoWiringWith2Argument),
+      ("testThatItUsesTagToResolveDependenciesWithAutoWiringWith3Argument", testThatItUsesTagToResolveDependenciesWithAutoWiringWith3Argument),
+      ("testThatItUsesTagToResolveDependenciesWithAutoWiringWith4Argument", testThatItUsesTagToResolveDependenciesWithAutoWiringWith4Argument),
+      ("testThatItUsesTagToResolveDependenciesWithAutoWiringWith5Argument", testThatItUsesTagToResolveDependenciesWithAutoWiringWith5Argument),
+      ("testThatItUsesTagToResolveDependenciesWithAutoWiringWith6Argument", testThatItUsesTagToResolveDependenciesWithAutoWiringWith6Argument)
     ]
   }
 
@@ -301,5 +308,104 @@ class AutoWiringTests: XCTestCase {
     XCTAssertTrue((resolved as! AutoWiredClientImp) !== (anotherInstance as! AutoWiredClientImp))
   }
   
+  func testThatItUsesTagToResolveDependenciesWithAutoWiringWith1Argument() {
+    //given
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(tag: "tag", .ObjectGraph) { ServiceImp2() as Service }
+    
+    container.register(.ObjectGraph) { (dep1: Service) -> ServiceImp3 in
+      XCTAssertTrue(dep1 is ServiceImp2)
+      return ServiceImp3()
+    }
+    
+    //when
+    let _ = try! container.resolve(tag: "tag") as ServiceImp3
+  }
+
+  func testThatItUsesTagToResolveDependenciesWithAutoWiringWith2Arguments() {
+    //given
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(tag: "tag", .ObjectGraph) { ServiceImp2() as Service }
+    
+    container.register(.ObjectGraph) { (dep1: Service, dep2: Service) -> ServiceImp3 in
+      XCTAssertTrue(dep1 is ServiceImp2)
+      XCTAssertTrue(dep2 is ServiceImp2)
+      return ServiceImp3()
+    }
+    
+    //when
+    let _ = try! container.resolve(tag: "tag") as ServiceImp3
+  }
+
+  func testThatItUsesTagToResolveDependenciesWithAutoWiringWith3Arguments() {
+    //given
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(tag: "tag", .ObjectGraph) { ServiceImp2() as Service }
+    
+    container.register(.ObjectGraph) { (dep1: Service, dep2: Service, dep3: Service) -> ServiceImp3 in
+      XCTAssertTrue(dep1 is ServiceImp2)
+      XCTAssertTrue(dep2 is ServiceImp2)
+      XCTAssertTrue(dep3 is ServiceImp2)
+      return ServiceImp3()
+    }
+    
+    //when
+    let _ = try! container.resolve(tag: "tag") as ServiceImp3
+  }
+
+  func testThatItUsesTagToResolveDependenciesWithAutoWiringWith4Arguments() {
+    //given
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(tag: "tag", .ObjectGraph) { ServiceImp2() as Service }
+    
+    container.register(.ObjectGraph) { (dep1: Service, dep2: Service, dep3: Service, dep4: Service) -> ServiceImp3 in
+      XCTAssertTrue(dep1 is ServiceImp2)
+      XCTAssertTrue(dep2 is ServiceImp2)
+      XCTAssertTrue(dep3 is ServiceImp2)
+      XCTAssertTrue(dep4 is ServiceImp2)
+      return ServiceImp3()
+    }
+    
+    //when
+    let _ = try! container.resolve(tag: "tag") as ServiceImp3
+  }
+
+  func testThatItUsesTagToResolveDependenciesWithAutoWiringWith5Arguments() {
+    //given
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(tag: "tag", .ObjectGraph) { ServiceImp2() as Service }
+    
+    container.register(.ObjectGraph) { (dep1: Service, dep2: Service, dep3: Service, dep4: Service, dep5: Service) -> ServiceImp3 in
+      XCTAssertTrue(dep1 is ServiceImp2)
+      XCTAssertTrue(dep2 is ServiceImp2)
+      XCTAssertTrue(dep3 is ServiceImp2)
+      XCTAssertTrue(dep4 is ServiceImp2)
+      XCTAssertTrue(dep5 is ServiceImp2)
+      return ServiceImp3()
+    }
+    
+    //when
+    let _ = try! container.resolve(tag: "tag") as ServiceImp3
+  }
+
+  func testThatItUsesTagToResolveDependenciesWithAutoWiringWith6Arguments() {
+    //given
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(tag: "tag", .ObjectGraph) { ServiceImp2() as Service }
+    
+    container.register(.ObjectGraph) { (dep1: Service, dep2: Service, dep3: Service, dep4: Service, dep5: Service, dep6: Service) -> ServiceImp3 in
+      XCTAssertTrue(dep1 is ServiceImp2)
+      XCTAssertTrue(dep2 is ServiceImp2)
+      XCTAssertTrue(dep3 is ServiceImp2)
+      XCTAssertTrue(dep4 is ServiceImp2)
+      XCTAssertTrue(dep5 is ServiceImp2)
+      XCTAssertTrue(dep6 is ServiceImp2)
+      return ServiceImp3()
+    }
+    
+    //when
+    let _ = try! container.resolve(tag: "tag") as ServiceImp3
+  }
+
 }
 

--- a/Sources/AutoWiring.swift
+++ b/Sources/AutoWiring.swift
@@ -75,7 +75,7 @@ extension DependencyContainer {
   }
   
   private func _resolveKey(key: DefinitionKey, tag: DependencyContainer.Tag?, type: Any.Type) throws -> Any? {
-    let key = DefinitionKey(protocolType: key.protocolType, argumentsType: key.argumentsType, associatedTag: tag)
+    let key = DefinitionKey(protocolType: key.protocolType, argumentsType: key.argumentsType, associatedTag: tag ?? context.tag)
     
     return try _resolveKey(key, builder: { definition throws -> Any in
       try definition.autoWiringFactory!(self, tag)

--- a/Sources/RuntimeArguments.swift
+++ b/Sources/RuntimeArguments.swift
@@ -89,7 +89,7 @@ extension DependencyContainer {
   
   /// - seealso: `register(tag:scope:factory:)`
   public func register<T, A, B, C>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Prototype, factory: (A, B, C) throws -> T) -> DefinitionOf<T, (A, B, C) throws -> T> {
-    return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 3)  { container, tag in try factory(container.resolve(tag: tag), container.resolve(), container.resolve(tag: tag)) }
+    return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 3)  { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   
   /// - seealso: `resolve(tag:withArguments:)`


### PR DESCRIPTION
Container context provides some information that can be useful for debugging configurations.

The other reason to introduce it is to be able to pass the tag to resolve dependencies, used to resolve dependent instance. 

Here is an example.
Without context:

```swift
container.register { DefaultDataSource() as ViewModelDataSource }
container.register(tag: "special") { SpecialDataSource() as ViewModelDataSource }

container.register { ViewModel() as ViewModel }
  .resolveDependencies { container, model in
    model.dataSource = try container.resolve() as ViewModelDataSource
}

container.register(tag: "special") { ViewModel() as ViewModel }
  .resolveDependencies { container, model in
    model.dataSource = try container.resolve(tag: "special") as ViewModelDataSource
}

let model = try container.resolve() as ViewModel
model.dataSource is DefaultDataSource // true

let specialModel = try container.resolve(tag: "special") as ViewModel
specialModel.dataSource is SpecialDataSource // true
```

So we need to register additional definition for `ViewModel` and hardcode the tag. If we add another implementation of data source registered with another tag we will need to register another `ViewModel` for the same tag again.

With context we don't need to register tagged definitions for `ViewModel` and hardcode tags:

```swift
container.register { DefaultDataSource() as ViewModelDataSource }
container.register(tag: "special") { SpecialDataSource() as ViewModelDataSource }

container.register { ViewModel() as ViewModel }
  .resolveDependencies { container, model in
    model.dataSource = try container.resolve(tag: container.context.tag) as ViewModelDataSource
}

let model = try container.resolve() as ViewModel
model.dataSource is DefaultDataSource // true

let specialModel = try container.resolve(tag: "special") as ViewModel
specialModel.dataSource is SpecialDataSource // true
```

Also context is used when auto-injecting properties to pass through tag used to resolve containing instance, unless auto-injected property explicitly specifies tag.