### PR TITLE
WeakSingleton scope

### DIFF
--- a/DipPlayground.playground/Pages/Scopes.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Scopes.xcplaygroundpage/Contents.swift
@@ -10,12 +10,13 @@ let container = DependencyContainer()
 
 Dip supports three different scopes of objects: _Prototype_, _ObjectGraph_ and _Singleton_.
 
-* The `.Prototype` scope will make the `DependencyContainer` resolve your type as __a new instance every time__ you call `resolve`. This is the default scope.
-* The `.ObjectGraph` scope is like `.Prototype` scope, but it will make the `DependencyContainer` to reuse resolved instances during one (recursive) call to `resolve` method. When this call returns, all resolved instances will be discarded and next call to `resolve` will produce new instances. This scope should be used to resolve [circular dependencies](Circular%20dependencies).
-* The `.Singleton` scope will make the `DependencyContainer` retain the instance once resolved the first time, and reuse it in the next calls to `resolve` during the container lifetime.
-* The `.EagerSingleton` scope is the same as `.Singleton` scope but instances with this cope will be created when you call `bootstrap()` method on the container.
+* The `Prototype` scope will make the `DependencyContainer` resolve your type as __a new instance every time__ you call `resolve`. This is the default scope.
+* The `ObjectGraph` scope is like `Prototype` scope, but it will make the `DependencyContainer` to reuse resolved instances during one (recursive) call to `resolve` method. When this call returns, all resolved instances will be discarded and next call to `resolve` will produce new instances. This scope should be used to resolve [circular dependencies](Circular%20dependencies).
+* The `Singleton` scope will make the `DependencyContainer` retain the instance once resolved the first time, and reuse it in the next calls to `resolve` during the container lifetime.
+* The `EagerSingleton` scope is the same as `Singleton` scope but instances with this cope will be created when you call `bootstrap()` method on the container.
+* The `WeakSingleton` scope is the same as `Singleton` scope but instances are stored in container as weak references. This scope can be usefull when you need to recreate object graph without reseting container.
 
-The `.Prototype` scope is the default. To set a scope you pass it as an argument to `register` method.
+The `Prototype` scope is the default. To set a scope you pass it as an argument to `register` method.
 */
 
 container.register { ServiceImp1() as Service }
@@ -31,13 +32,13 @@ service as! ServiceImp1 === anotherService as! ServiceImp1 // false
 let prototypeService = try! container.resolve(tag: "prototype") as Service
 let anotherPrototypeService = try! container.resolve(tag: "prototype") as Service
 // They are different instances:
-prototypeService as! ServiceImp1 === anotherPrototypeService as! ServiceImp1 // false
+prototypeService === anotherPrototypeService // false
 
 let graphService = try! container.resolve(tag: "object graph") as Service
 let anotherGraphService = try! container.resolve(tag: "object graph") as Service
 // still different instances — the ObjectGraph scope only keep instances during one (recursive) resolution call,
 // so the two calls on the two lines above are different calls and use different instances
-graphService as! ServiceImp2 === anotherGraphService as! ServiceImp2 // false
+graphService === anotherGraphService // false
 
 let sharedService = try! container.resolve(tag: "shared instance") as Service
 let sameSharedService = try! container.resolve(tag: "shared instance") as Service

--- a/DipPlayground.playground/Sources/Models.swift
+++ b/DipPlayground.playground/Sources/Models.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol Service {}
+public protocol Service: class {}
 
 public class ServiceImp1: Service {
   public init() {}

--- a/DipPlayground.playground/contents.xcplayground
+++ b/DipPlayground.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='ios' display-mode='raw'>
+<playground version='6.0' target-platform='ios' display-mode='rendered'>
     <pages>
         <page name='What is Dip?'/>
         <page name='Creating container'/>

--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -111,7 +111,7 @@ public enum ComponentScope {
   /**
    Resolved instance will be retained by the container and always reused.
    Do not mix this life cycle with _singleton pattern_.
-   Instance will be not shared between different containers.
+   Instance will be not shared between different containers unless they collaborate.
    
    - warning: Make sure this component is thread safe or accessed always from the same thread.
    
@@ -139,11 +139,18 @@ public enum ComponentScope {
   case Singleton
   
   /**
-   The same scope as `Singleton`, but instance will be created when container is bootstrapped.
+   The same scope as a `Singleton`, but instance will be created when container is bootstrapped.
    
    - seealso: `bootstrap()`
   */
   case EagerSingleton
+  
+  /**
+   The same scope as a `Singleton`, but container stores week reference to the resolved instance.
+   While a strong reference to the resolved instance exists resolve will return the same instance.
+   After the resolved instance is deallocated next resolve will produce a new instance.
+  */
+  case WeakSingleton
 }
 
 ///Dummy protocol to store definitions for different types in collection

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -449,6 +449,7 @@ extension DependencyContainer {
      let anyService: Any = optService
      let service: Service = anyService as! Service
      
+     That happens because when Optional is casted to Any Swift can not implicitly unwrap it with as operator.
      As a workaround we detect boxing here and unwrap it so that we return not a box, but wrapped instance.
      */
     if let box = resolvedInstance as? BoxType, unboxed = box.unboxed as? T {

--- a/Sources/Utils.swift
+++ b/Sources/Utils.swift
@@ -34,10 +34,44 @@ func log(logLevel: LogLevel, _ message: Any) {
   print(message)
 }
 
-class WeakBox<T: AnyObject> {
-  weak var value: T?
+///Internal protocol used to unwrap optional values.
+protocol BoxType {
+  var unboxed: Any? { get }
+}
+
+extension Optional: BoxType {
+  var unboxed: Any? {
+    switch self {
+    case let .Some(value): return value
+    default: return nil
+    }
+  }
+}
+
+extension ImplicitlyUnwrappedOptional: BoxType {
+  var unboxed: Any? {
+    switch self {
+    case let .Some(value): return value
+    default: return nil
+    }
+  }
+}
+
+protocol WeakBoxType {
+  var unboxed: AnyObject? { get }
+}
+
+class WeakBox<T>: WeakBoxType {
+  weak var unboxed: AnyObject?
+  var value: T? {
+    return unboxed as? T
+  }
+
   init(value: T) {
-    self.value = value
+    guard let value = value as? AnyObject else {
+      fatalError("Can not store weak reference to not a class instance (\(T.self))")
+    }
+    self.unboxed = value
   }
 }
 

--- a/Tests/Dip/AutoWiringTests.swift
+++ b/Tests/Dip/AutoWiringTests.swift
@@ -62,7 +62,7 @@ class AutoWiringTests: XCTestCase {
       ("testThatItDoesNotUseAutoWiringWhenFailedToResolveLowLevelDependency", testThatItDoesNotUseAutoWiringWhenFailedToResolveLowLevelDependency),
       ("testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgain", testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgain),
       ("testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithTheSameTag", testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithTheSameTag),
-      ("testThatItDoesNotReuseInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithNoTag", testThatItDoesNotReuseInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithNoTag),
+      ("testThatItDoesNotReuseInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithAnotherTag", testThatItDoesNotReuseInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithAnotherTag),
       ("testThatItUsesTagToResolveDependenciesWithAutoWiringWith1Argument", testThatItUsesTagToResolveDependenciesWithAutoWiringWith1Argument),
       ("testThatItUsesTagToResolveDependenciesWithAutoWiringWith2Arguments", testThatItUsesTagToResolveDependenciesWithAutoWiringWith2Arguments),
       ("testThatItUsesTagToResolveDependenciesWithAutoWiringWith3Arguments", testThatItUsesTagToResolveDependenciesWithAutoWiringWith3Arguments),
@@ -265,6 +265,31 @@ class AutoWiringTests: XCTestCase {
     XCTAssertTrue((resolved as! AutoWiredClientImp) === (anotherInstance as! AutoWiredClientImp))
   }
   
+  func testThatItReusesInstancesResolvedWithoutAutoWiringWhenUsingAutoWiringAgain() {
+    
+    //given
+    container.register(.ObjectGraph) { ServiceImp1() as Service }
+    container.register(.ObjectGraph) { ServiceImp2() }
+    
+    var anotherInstance: AutoWiredClient?
+    
+    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+      .resolveDependencies { container, _ in
+        if anotherInstance == nil {
+          anotherInstance = try! container.resolve() as AutoWiredClient
+        }
+    }
+    
+    //when
+    let service1 = try! container.resolve() as Service?
+    let service2 = try! container.resolve() as ServiceImp2
+    let resolved = try! container.resolve(withArguments: service1, service2) as AutoWiredClient
+    
+    //then
+    //when doing another auto-wiring during resolve we should reuse instance
+    XCTAssertTrue((resolved as! AutoWiredClientImp) === (anotherInstance as! AutoWiredClientImp))
+  }
+
   func testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithTheSameTag() {
     
     //given

--- a/Tests/Dip/ComponentScopeTests.swift
+++ b/Tests/Dip/ComponentScopeTests.swift
@@ -62,7 +62,9 @@ class ComponentScopeTests: XCTestCase {
       ("testThatItDoesNotReuseInstanceInObjectGraphScopeInNextResolve", testThatItDoesNotReuseInstanceInObjectGraphScopeInNextResolve),
       ("testThatItDoesNotReuseInstanceInObjectGraphScopeResolvedForNilTag", testThatItDoesNotReuseInstanceInObjectGraphScopeResolvedForNilTagWhenResolvingForAnotherTag),
       ("testThatItReusesInstanceInObjectGraphScopeResolvedForNilTag", testThatItReusesInstanceInObjectGraphScopeResolvedForNilTag),
-      ("testThatItReusesResolvedInstanceWhenResolvingOptional", testThatItReusesResolvedInstanceWhenResolvingOptional)
+      ("testThatItReusesResolvedInstanceWhenResolvingOptional", testThatItReusesResolvedInstanceWhenResolvingOptional),
+      ("testThatItHoldsWeakReferenceToWeakSingletonInstance",
+          testThatItHoldsWeakReferenceToWeakSingletonInstance)
     ]
   }
   
@@ -318,5 +320,20 @@ class ComponentScopeTests: XCTestCase {
     XCTAssertTrue(anyImpOtherService as! ServiceImp1 === service as! ServiceImp1)
   }
   
+  func testThatItHoldsWeakReferenceToWeakSingletonInstance() {
+    //given
+    container.register(.WeakSingleton) { ServiceImp1() as Service }
+    var strongSingleton: Service? = try! container.resolve() as Service
+    weak var weakSingleton = try! container.resolve() as Service
+    
+    //then
+    XCTAssertTrue(weakSingleton === strongSingleton)
+    
+    //when
+    strongSingleton = nil
+    
+    //then
+    XCTAssertNil(weakSingleton)
+  }
 }
 

--- a/Tests/Dip/DipTests.swift
+++ b/Tests/Dip/DipTests.swift
@@ -634,7 +634,7 @@ extension DipTests {
     XCTAssertNil(weakCollaborator)
   }
   
-  func testThatCollaboratingContainersReuseInstances() {
+  func testThatCollaboratingContainersReuseInstancesResolvedByAnotherContainer() {
     //given
     class ServerImp: Server {
       weak var client: Client?
@@ -661,14 +661,21 @@ extension DipTests {
     //when
     serverContainer.collaborate(with: clientContainer)
     clientContainer.collaborate(with: serverContainer)
-    let client = try? clientContainer.resolve() as Client
+    var client = try? clientContainer.resolve() as Client
     
     //then
     XCTAssertNotNil(client)
     XCTAssertTrue(client === client?.server?.client)
     XCTAssertTrue(client === (client as? ClientImp)?.anotherServer?.client)
-    XCTAssertTrue(client?.server === (client as? ClientImp)?.anotherServer
-    )
+    XCTAssertTrue(client?.server === (client as? ClientImp)?.anotherServer)
+    
+    client = try? serverContainer.resolve() as Client
+    
+    //then
+    XCTAssertNotNil(client)
+    XCTAssertTrue(client === client?.server?.client)
+    XCTAssertTrue(client === (client as? ClientImp)?.anotherServer?.client)
+    XCTAssertTrue(client?.server === (client as? ClientImp)?.anotherServer)
   }
   
 }


### PR DESCRIPTION
This scope can be usefull when there is a need to recreate objects graph at runtime without reseting container and registering all components again.
For example when user changes a language inside application and all its components (UI and business logic) should be recreated. 

It is analogous to TyphoonScopeWeakSingleton scope present in Typhoon