### PR TITLE
Grand renaming

### DIFF
--- a/Dip/DipTests/TypeForwardingTests.swift
+++ b/Dip/DipTests/TypeForwardingTests.swift
@@ -79,7 +79,7 @@ class TypeForwardingTests: XCTestCase {
   func testThatItReusesInstanceResolvedByTypeForwarding() {
     //given
     let def = container.register(.Shared) { ServiceImp1() as Service }
-      .resolveDependencies { container, resolved in
+      .resolvingProperties { container, resolved in
         //when
         let forwardType = try container.resolve() as ForwardedType
         let anyForwardType = try container.resolve(ForwardedType.self) as! ForwardedType
@@ -125,7 +125,7 @@ class TypeForwardingTests: XCTestCase {
     var resolveDependenciesCalled = false
     //given
     let def = container.register(.Shared) { ServiceImp1() as Service }
-      .resolveDependencies { container, service in
+      .resolvingProperties { container, service in
         guard resolveDependenciesCalled == false else { return }
         resolveDependenciesCalled = true
 
@@ -153,12 +153,12 @@ class TypeForwardingTests: XCTestCase {
     var originalResolveDependenciesCalled = false
     var resolveDependenciesCalled = false
     let def = container.register { ServiceImp1() }
-      .resolveDependencies { container, service in
+      .resolvingProperties { container, service in
         originalResolveDependenciesCalled = true
     }
     
     container.register(def, type: Service.self)
-      .resolveDependencies { container, object in
+      .resolvingProperties { container, object in
         resolveDependenciesCalled = true
     }
     
@@ -196,7 +196,7 @@ class TypeForwardingTests: XCTestCase {
   func testThatItFirstUsesTaggedDefinitionWhenResolvingOptional() {
     let expectedTag: DependencyContainer.Tag = .String("tag")
     container.register(tag: expectedTag) { ServiceImp1() as Service }
-      .resolveDependencies { container, resolved in
+      .resolvingProperties { container, resolved in
         XCTAssertEqual(container.context.tag, expectedTag)
     }
     container.register { ServiceImp2() as Service }

--- a/Dip/DipTests/TypeForwardingTests.swift
+++ b/Dip/DipTests/TypeForwardingTests.swift
@@ -78,7 +78,7 @@ class TypeForwardingTests: XCTestCase {
   
   func testThatItReusesInstanceResolvedByTypeForwarding() {
     //given
-    let def = container.register(.ObjectGraph) { ServiceImp1() as Service }
+    let def = container.register(.Shared) { ServiceImp1() as Service }
       .resolveDependencies { container, resolved in
         //when
         let forwardType = try container.resolve() as ForwardedType
@@ -124,7 +124,7 @@ class TypeForwardingTests: XCTestCase {
   func testThatItDoesNotReuseInstanceResolvedByTypeForwardingRegisteredForAnotherTag() {
     var resolveDependenciesCalled = false
     //given
-    let def = container.register(.ObjectGraph) { ServiceImp1() as Service }
+    let def = container.register(.Shared) { ServiceImp1() as Service }
       .resolveDependencies { container, service in
         guard resolveDependenciesCalled == false else { return }
         resolveDependenciesCalled = true

--- a/DipPlayground.playground/Pages/Auto-injection.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Auto-injection.xcplaygroundpage/Contents.swift
@@ -31,7 +31,7 @@ container.register() { TrackerImp() as Tracker }
 container.register() { LoggerImp() as Logger }
 
 container.register() { ServiceImp() as Service }
-    .resolveDependencies { container, service in
+    .resolvingProperties { container, service in
         let service = service as! ServiceImp
         service.logger = try container.resolve() as Logger
         service.tracker = try container.resolve() as Tracker
@@ -132,7 +132,7 @@ container.register(.Shared) {
 }
 
 container.register(.Shared) { ServerImp() as Server }
-    .resolveDependencies { (container: DependencyContainer, server: Server) in
+    .resolvingProperties { (container: DependencyContainer, server: Server) in
         (server as! ServerImp).client = try container.resolve() as ServerClient
 }
 
@@ -176,7 +176,7 @@ class ViewController: UIViewController {
 }
 
 container.register { ViewController() }
-    .resolveDependencies { container, controller in
+    .resolvingProperties { container, controller in
         controller.logger = try container.resolve() as Logger
         controller.tracker = try container.resolve() as Tracker
         controller.dataProvider = try container.resolve() as DataProvider

--- a/DipPlayground.playground/Pages/Auto-injection.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Auto-injection.xcplaygroundpage/Contents.swift
@@ -127,11 +127,11 @@ class ServerClientImp: ServerClient {
 The standard way to register such components in `DependencyContainer` will lead to such code:
 */
 
-container.register(.ObjectGraph) {
+container.register(.Shared) {
     ServerClientImp(server: try container.resolve()) as ServerClient
 }
 
-container.register(.ObjectGraph) { ServerImp() as Server }
+container.register(.Shared) { ServerImp() as Server }
     .resolveDependencies { (container: DependencyContainer, server: Server) in
         (server as! ServerImp).client = try container.resolve() as ServerClient
 }
@@ -153,8 +153,8 @@ class InjectedClientImp: ServerClient {
     var server: Server? { get { return injectedServer.value } }
 }
 
-container.register(.ObjectGraph) { InjectedServerImp() as Server }
-container.register(.ObjectGraph) { InjectedClientImp() as ServerClient }
+container.register(.Shared) { InjectedServerImp() as Server }
+container.register(.Shared) { InjectedClientImp() as ServerClient }
 
 let injectedClient = try! container.resolve() as ServerClient
 injectedClient.server

--- a/DipPlayground.playground/Pages/Auto-wiring.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Auto-wiring.xcplaygroundpage/Contents.swift
@@ -86,10 +86,10 @@ But then to resolve presenter or interactor you will first need to resolve their
 */
 
 let service = try! container.resolve() as Service
-let interactor = try! container.resolve(withArguments: service) as Interactor
+let interactor = try! container.resolve(arguments: service) as Interactor
 let view = try! container.resolve() as ViewOutput
 let router = try! container.resolve() as Router
-presenter = try! container.resolve(withArguments: view, interactor, router) as Presenter
+presenter = try! container.resolve(arguments: view, interactor, router) as Presenter
 presenter.interactor.service
 
 /*:

--- a/DipPlayground.playground/Pages/Circular dependencies.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Circular dependencies.xcplaygroundpage/Contents.swift
@@ -48,7 +48,7 @@ container.register(.Shared) {
 }
 
 container.register(.Shared) { NetworkClientImp() as NetworkClient }
-    .resolveDependencies { (container, client) -> () in
+    .resolvingProperties { (container, client) -> () in
         client.delegate = try container.resolve() as NetworkClientDelegate
 }
 
@@ -96,7 +96,7 @@ container.register(.Unique) {
 }
 
 container.register(.Shared) { NetworkClientImp() as NetworkClient }
-    .resolveDependencies { (container, client) -> () in
+    .resolvingProperties { (container, client) -> () in
         client.delegate = try container.resolve() as NetworkClientDelegate
 }
 

--- a/DipPlayground.playground/Pages/Circular dependencies.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Circular dependencies.xcplaygroundpage/Contents.swift
@@ -43,11 +43,11 @@ It's very important that _at least one_ of them uses property injection, because
 Now you can register those classes in container:
 */
 
-container.register(.ObjectGraph) {
+container.register(.Shared) {
     Interactor(networkClient: try container.resolve()) as NetworkClientDelegate
 }
 
-container.register(.ObjectGraph) { NetworkClientImp() as NetworkClient }
+container.register(.Shared) { NetworkClientImp() as NetworkClient }
     .resolveDependencies { (container, client) -> () in
         client.delegate = try container.resolve() as NetworkClientDelegate
 }
@@ -77,25 +77,25 @@ let networkClient = try! container.resolve() as NetworkClient
 networkClient.delegate // delegate was alread released =(
 
 /*:
-Note also that we used `.ObjectGraph` scope to register implementations. This is also very important to preserve consistency of objects relationships.
+Note also that we used `.Shared` scope to register implementations. This is also very important to preserve consistency of objects relationships.
 
-If we would have used `.Prototype` scope for both components then container would not reuse instances and we would have an infinite loop:
+If we would have used `.Unique` scope for both components then container would not reuse instances and we would have an infinite loop:
 
  - Each attempt to resolve `NetworkClientDelegate` will create new instance of `Interactor`.
  - It will resolve `NetworkClient` which will create new instance of `NetworkClientImp`.
  - It will try to resolve it's delegate property and that will create new instance of `Interactor`
  - … And so on and so on.
 
-If we would have used `.Prototype` for one of the components it will lead to the same infinite loop or one of the relationships will be invalid:
+If we would have used `.Unique` for one of the components it will lead to the same infinite loop or one of the relationships will be invalid:
 */
 
 container.reset()
 
-container.register(.Prototype) {
+container.register(.Unique) {
     Interactor(networkClient: try container.resolve()) as NetworkClientDelegate
 }
 
-container.register(.ObjectGraph) { NetworkClientImp() as NetworkClient }
+container.register(.Shared) { NetworkClientImp() as NetworkClient }
     .resolveDependencies { (container, client) -> () in
         client.delegate = try container.resolve() as NetworkClientDelegate
 }

--- a/DipPlayground.playground/Pages/Containers Collaboration.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Containers Collaboration.xcplaygroundpage/Contents.swift
@@ -26,7 +26,7 @@ let rootContainer = DependencyContainer()
 rootContainer.register(.Singleton) { CoreDataStore() as DataStore }
 
 let eventsListModule = DependencyContainer()
-eventsListModule.register(.ObjectGraph) { EventsListWireframe(dataStore: $0) }
+eventsListModule.register(.Shared) { EventsListWireframe(dataStore: $0) }
     .resolveDependencies { container, wireframe in
         wireframe.addEventWireframe = try container.resolve()
 }
@@ -48,12 +48,12 @@ eventsListWireframe.addEventWireframe
 eventsListModule.reset()
 addEventModule.reset()
 
-eventsListModule.register(.ObjectGraph) { EventsListWireframe(dataStore: $0) }
+eventsListModule.register(.Shared) { EventsListWireframe(dataStore: $0) }
     .resolveDependencies { container, wireframe in
         wireframe.addEventWireframe = try container.resolve()
 }
 
-addEventModule.register(.ObjectGraph) { AddEventWireframe() }
+addEventModule.register(.Shared) { AddEventWireframe() }
     .resolveDependencies { container, wireframe in
         wireframe.eventsListWireframe = try container.resolve()
 }

--- a/DipPlayground.playground/Pages/Containers Collaboration.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Containers Collaboration.xcplaygroundpage/Contents.swift
@@ -27,7 +27,7 @@ rootContainer.register(.Singleton) { CoreDataStore() as DataStore }
 
 let eventsListModule = DependencyContainer()
 eventsListModule.register(.Shared) { EventsListWireframe(dataStore: $0) }
-    .resolveDependencies { container, wireframe in
+    .resolvingProperties { container, wireframe in
         wireframe.addEventWireframe = try container.resolve()
 }
 
@@ -49,12 +49,12 @@ eventsListModule.reset()
 addEventModule.reset()
 
 eventsListModule.register(.Shared) { EventsListWireframe(dataStore: $0) }
-    .resolveDependencies { container, wireframe in
+    .resolvingProperties { container, wireframe in
         wireframe.addEventWireframe = try container.resolve()
 }
 
 addEventModule.register(.Shared) { AddEventWireframe() }
-    .resolveDependencies { container, wireframe in
+    .resolvingProperties { container, wireframe in
         wireframe.eventsListWireframe = try container.resolve()
 }
 

--- a/DipPlayground.playground/Pages/Resolving components.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Resolving components.xcplaygroundpage/Contents.swift
@@ -41,6 +41,6 @@ let defaultService = try! container.resolve() as Service
 You can use runtime arguments to resolve components. Dip supports up to six arguments. For more details see ["Runtime arguments"](Runtime%20arguments).
 */
 container.register { service in ClientImp1(service: service) as Client }
-let client = try! container.resolve(withArguments: service) as Client
+let client = try! container.resolve(arguments: service) as Client
 
 //: [Next: Runtime Arguments](@next)

--- a/DipPlayground.playground/Pages/Runtime arguments.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Runtime arguments.xcplaygroundpage/Contents.swift
@@ -18,10 +18,10 @@ container.register { (port: Int, url: NSURL?) in ServiceImp4(name: "3", baseURL:
 container.register { (port: Int, url: NSURL!) in ServiceImp4(name: "4", baseURL: url, port: port) as Service }
 
 let url: NSURL = NSURL(string: "http://example.com")!
-let service1 = try! container.resolve(withArguments: url, 80) as Service
-let service2 = try! container.resolve(withArguments: 80, url) as Service
-let service3 = try! container.resolve(withArguments: 80, NSURL(string: "http://example.com")) as Service
-let service4 = try! container.resolve(withArguments: 80, NSURL(string: "http://example.com")! as NSURL!) as Service
+let service1 = try! container.resolve(arguments: url, 80) as Service
+let service2 = try! container.resolve(arguments: 80, url) as Service
+let service3 = try! container.resolve(arguments: 80, NSURL(string: "http://example.com")) as Service
+let service4 = try! container.resolve(arguments: 80, NSURL(string: "http://example.com")! as NSURL!) as Service
 
 (service1 as! ServiceImp4).name
 (service2 as! ServiceImp4).name

--- a/DipPlayground.playground/Pages/Runtime arguments.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Runtime arguments.xcplaygroundpage/Contents.swift
@@ -35,7 +35,7 @@ _Dip_ supports up to six runtime arguments. If that is not enougth you can exten
 */
 
 extension DependencyContainer {
-    public func register<T, A, B, C, D, E, F, G>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Prototype, factory: (A, B, C, D, E, F, G) throws -> T) -> DefinitionOf<T, (A, B, C, D, E, F, G) throws -> T> {
+    public func register<T, A, B, C, D, E, F, G>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Unique, factory: (A, B, C, D, E, F, G) throws -> T) -> DefinitionOf<T, (A, B, C, D, E, F, G) throws -> T> {
         return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 7) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag))
         }
     }

--- a/DipPlayground.playground/Pages/Scopes.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Scopes.xcplaygroundpage/Contents.swift
@@ -54,7 +54,7 @@ sharedService as! ServiceImp3 === sameSharedService as! ServiceImp3
 
 var resolvedEagerSingleton = false
 let definition = container.register(tag: "eager shared instance", .EagerSingleton) { ServiceImp1() as Service }
-    .resolveDependencies { _ in resolvedEagerSingleton = true }
+    .resolvingProperties { _ in resolvedEagerSingleton = true }
 
 try! container.bootstrap()
 resolvedEagerSingleton

--- a/DipPlayground.playground/Pages/Scopes.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Scopes.xcplaygroundpage/Contents.swift
@@ -8,35 +8,35 @@ let container = DependencyContainer()
 
 ### Scopes
 
-Dip supports three different scopes of objects: _Prototype_, _ObjectGraph_ and _Singleton_.
+Dip supports three different scopes of objects: _Unique_, _Shared_ and _Singleton_.
 
-* The `Prototype` scope will make the `DependencyContainer` resolve your type as __a new instance every time__ you call `resolve`. This is the default scope.
-* The `ObjectGraph` scope is like `Prototype` scope, but it will make the `DependencyContainer` to reuse resolved instances during one (recursive) call to `resolve` method. When this call returns, all resolved instances will be discarded and next call to `resolve` will produce new instances. This scope should be used to resolve [circular dependencies](Circular%20dependencies).
+* The `Unique` scope will make the `DependencyContainer` resolve your type as __a new instance every time__ you call `resolve`. This is the default scope.
+* The `Shared` scope is like `Unique` scope, but it will make the `DependencyContainer` to reuse resolved instances during one (recursive) call to `resolve` method. When this call returns, all resolved instances will be discarded and next call to `resolve` will produce new instances. This scope should be used to resolve [circular dependencies](Circular%20dependencies).
 * The `Singleton` scope will make the `DependencyContainer` retain the instance once resolved the first time, and reuse it in the next calls to `resolve` during the container lifetime.
 * The `EagerSingleton` scope is the same as `Singleton` scope but instances with this cope will be created when you call `bootstrap()` method on the container.
 * The `WeakSingleton` scope is the same as `Singleton` scope but instances are stored in container as weak references. This scope can be usefull when you need to recreate object graph without reseting container.
 
-The `Prototype` scope is the default. To set a scope you pass it as an argument to `register` method.
+The `Unique` scope is the default. To set a scope you pass it as an argument to `register` method.
 */
 
 container.register { ServiceImp1() as Service }
-container.register(tag: "prototype", .Prototype) { ServiceImp1() as Service }
-container.register(tag: "object graph", .ObjectGraph) { ServiceImp2() as Service }
+container.register(tag: "prototype", .Unique) { ServiceImp1() as Service }
+container.register(tag: "object graph", .Shared) { ServiceImp2() as Service }
 container.register(tag: "shared instance", .Singleton) { ServiceImp3() as Service }
 
 let service = try! container.resolve() as Service
 let anotherService = try! container.resolve() as Service
-// They are different instances as the scope defaults to .Prototype
+// They are different instances as the scope defaults to .Unique
 service as! ServiceImp1 === anotherService as! ServiceImp1 // false
 
 let prototypeService = try! container.resolve(tag: "prototype") as Service
-let anotherPrototypeService = try! container.resolve(tag: "prototype") as Service
+let anotherUniqueService = try! container.resolve(tag: "prototype") as Service
 // They are different instances:
-prototypeService === anotherPrototypeService // false
+prototypeService === anotherUniqueService // false
 
 let graphService = try! container.resolve(tag: "object graph") as Service
 let anotherGraphService = try! container.resolve(tag: "object graph") as Service
-// still different instances — the ObjectGraph scope only keep instances during one (recursive) resolution call,
+// still different instances — the Shared scope only keep instances during one (recursive) resolution call,
 // so the two calls on the two lines above are different calls and use different instances
 graphService === anotherGraphService // false
 

--- a/DipPlayground.playground/Pages/Testing.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Testing.xcplaygroundpage/Contents.swift
@@ -59,7 +59,7 @@ class FakeService: ServiceType {
 func configure(container: DependencyContainer) {
     container.register { RealService() as ServiceType }
     container.register { Client() }
-        .resolveDependencies { container, client in
+        .resolvingProperties { container, client in
             client.service = try container.resolve()
     }
 }

--- a/DipPlayground.playground/Pages/Type Forwarding.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Type Forwarding.xcplaygroundpage/Contents.swift
@@ -27,21 +27,21 @@ extension AddPresenter: AddModuleInterface {}
  We can achieve this result by explicitly rosolving concrete types:
  */
 
-container.register(.ObjectGraph) { ListWireframe(addWireFrame: $0, listPresenter: $1) }
-container.register(.ObjectGraph) { AddWireframe(addPresenter: $0) }
+container.register(.Shared) { ListWireframe(addWireFrame: $0, listPresenter: $1) }
+container.register(.Shared) { AddWireframe(addPresenter: $0) }
 
-var listInteractorDefinition = container.register(.ObjectGraph) { ListInteractor() }
+var listInteractorDefinition = container.register(.Shared) { ListInteractor() }
     .resolveDependencies { container, interactor in
         interactor.output = try container.resolve() as ListPresenter
 }
 
-var listPresenterDefinition = container.register(.ObjectGraph) { ListPresenter() }
+var listPresenterDefinition = container.register(.Shared) { ListPresenter() }
     .resolveDependencies { container, presenter in
         presenter.listInteractor = try container.resolve() as ListInteractor
         presenter.listWireframe = try container.resolve()
 }
 
-var addPresenterDefinition = container.register(.ObjectGraph) { AddPresenter() }
+var addPresenterDefinition = container.register(.Shared) { AddPresenter() }
     .resolveDependencies { container, presenter in
         presenter.addModuleDelegate = try container.resolve() as ListPresenter
 }
@@ -54,21 +54,21 @@ var listWireframe = listPresenter.listWireframe
 listWireframe?.listPresenter === listPresenter
 
 /*:
- Alternatively we can use type-forwarding. With type-forwarding we register definition for one (source) type and also for another (forwarded) type. When container will try to resolve forwarded type it will use the same definition as for source type, and (if registered in `ObjectGraph` scope or as a singleton) will reuse the same instance. With that you don't need to resolve concrete types in definitions:
+ Alternatively we can use type-forwarding. With type-forwarding we register definition for one (source) type and also for another (forwarded) type. When container will try to resolve forwarded type it will use the same definition as for source type, and (if registered in `Shared` scope or as a singleton) will reuse the same instance. With that you don't need to resolve concrete types in definitions:
  */
 
-listInteractorDefinition = container.register(.ObjectGraph) { ListInteractor() }
+listInteractorDefinition = container.register(.Shared) { ListInteractor() }
     .resolveDependencies { container, interactor in
         interactor.output = try container.resolve()
 }
 
-listPresenterDefinition = container.register(.ObjectGraph) { ListPresenter() }
+listPresenterDefinition = container.register(.Shared) { ListPresenter() }
     .resolveDependencies { container, presenter in
         presenter.listInteractor = try container.resolve()
         presenter.listWireframe = try container.resolve()
 }
 
-addPresenterDefinition = container.register(.ObjectGraph) { AddPresenter() }
+addPresenterDefinition = container.register(.Shared) { AddPresenter() }
     .resolveDependencies { container, presenter in
         presenter.addModuleDelegate = try container.resolve()
 }

--- a/DipPlayground.playground/Pages/Type Forwarding.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Type Forwarding.xcplaygroundpage/Contents.swift
@@ -31,18 +31,18 @@ container.register(.Shared) { ListWireframe(addWireFrame: $0, listPresenter: $1)
 container.register(.Shared) { AddWireframe(addPresenter: $0) }
 
 var listInteractorDefinition = container.register(.Shared) { ListInteractor() }
-    .resolveDependencies { container, interactor in
+    .resolvingProperties { container, interactor in
         interactor.output = try container.resolve() as ListPresenter
 }
 
 var listPresenterDefinition = container.register(.Shared) { ListPresenter() }
-    .resolveDependencies { container, presenter in
+    .resolvingProperties { container, presenter in
         presenter.listInteractor = try container.resolve() as ListInteractor
         presenter.listWireframe = try container.resolve()
 }
 
 var addPresenterDefinition = container.register(.Shared) { AddPresenter() }
-    .resolveDependencies { container, presenter in
+    .resolvingProperties { container, presenter in
         presenter.addModuleDelegate = try container.resolve() as ListPresenter
 }
 
@@ -58,18 +58,18 @@ listWireframe?.listPresenter === listPresenter
  */
 
 listInteractorDefinition = container.register(.Shared) { ListInteractor() }
-    .resolveDependencies { container, interactor in
+    .resolvingProperties { container, interactor in
         interactor.output = try container.resolve()
 }
 
 listPresenterDefinition = container.register(.Shared) { ListPresenter() }
-    .resolveDependencies { container, presenter in
+    .resolvingProperties { container, presenter in
         presenter.listInteractor = try container.resolve()
         presenter.listWireframe = try container.resolve()
 }
 
 addPresenterDefinition = container.register(.Shared) { AddPresenter() }
-    .resolveDependencies { container, presenter in
+    .resolvingProperties { container, presenter in
         presenter.addModuleDelegate = try container.resolve()
 }
 
@@ -97,11 +97,11 @@ listWireframe?.listPresenter === listPresenter
  You can also provide `resolveDependencies` block for forwarded definition. First container will call `resolveDependencies` block of the source definition, and then of forwarded definition:
  */
 listInteractorDefinition
-    .resolveDependencies { container, interactor in
+    .resolvingProperties { container, interactor in
         print("resolved ListInteractor")
 }
 container.register(listInteractorDefinition, type: ListInteractorInput.self)
-    .resolveDependencies { container, interactor in
+    .resolvingProperties { container, interactor in
         print("resolved ListInteractorInput")
 }
 addPresenter = try! container.resolve() as AddPresenter

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ File an issue if you have any question.
 
 ## Features
 
-- **[Scopes](../../wiki/scopes)**. Dip supports 5 different scopes (or life cycle strategies): _Prototype_, _ObjectGraph_, _Singleton_, _EagerSingleton_, _WeakSingleton_;
+- **[Scopes](../../wiki/scopes)**. Dip supports 5 different scopes (or life cycle strategies): _Prototype_, _Shared_, _Singleton_, _EagerSingleton_, _WeakSingleton_;
 - **[Named definitions](../../wiki/named-definitions)**. You can register different factories for the same protocol or type by registering them with [tags]();
 - **[Runtime arguments](../../wiki/runtime-arguments)**. You can register factories that accept up to 6 runtime arguments;
 - **[Circular dependencies](../../wiki/circular-dependencies)**. Dip can resolve circular dependencies;

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ extension DependencyContainer {
 	static func configure() -> DependencyContainer {
 		return DependencyContainer { container in 
 			container.register(tag: "ViewController") { ViewController() }
-			  .resolveDependencies { container, controller in
+			  .resolvingProperties { container, controller in
 				  controller.animationsFactory = try container.resolve() as AnimatonsFactory
 			}
     

--- a/SampleApp/DipSampleApp/DependencyContainers.swift
+++ b/SampleApp/DipSampleApp/DependencyContainers.swift
@@ -33,7 +33,7 @@ func configureContainer(dip: DependencyContainer) {
         // 1) Register fake persons provider
         //Here we use constructor injection for one of the dependencies property injection for another, and we provide dependencies manually
         dip.register() { FakePersonsProvider(dummyProvider: DummyPilotProvider()) as PersonProviderAPI }
-            .resolveDependencies { (_, resolved: PersonProviderAPI) in
+            .resolvingProperties { (_, resolved: PersonProviderAPI) in
                 //here we resolve optional dependencies
                 //see what happens when you comment this out
                 (resolved as! FakePersonsProvider).plistProvider = PlistPersonProvider(plist: "mainPilot")

--- a/SampleApp/DipSampleApp/DependencyContainers.swift
+++ b/SampleApp/DipSampleApp/DependencyContainers.swift
@@ -60,7 +60,7 @@ func configureContainer(dip: DependencyContainer) {
         //Here we use constructor injection, but instead of providing dependencies manually container resolves them for us
         dip.register() {
             FakeStarshipProvider(
-                dummyProvider: try dip.resolve(tag: DependencyTags.Dummy, withArguments: "Main Pilot"),
+                dummyProvider: try dip.resolve(tag: DependencyTags.Dummy, arguments: "Main Pilot"),
                 hardCodedProvider: try dip.resolve(tag: DependencyTags.Hardcoded)) as StarshipProviderAPI
         }
         

--- a/Sources/AutoInjection.swift
+++ b/Sources/AutoInjection.swift
@@ -34,7 +34,7 @@ extension DependencyContainer {
   private func resolveChild(child: Mirror.Child) throws {
     guard let injectedPropertyBox = child.value as? AutoInjectedPropertyBox else { return }
     
-    let contextKey = DefinitionKey(protocolType: injectedPropertyBox.dynamicType.wrappedType, argumentsType: Void.self, associatedTag: context.tag)
+    let contextKey = DefinitionKey(type: injectedPropertyBox.dynamicType.wrappedType, typeOfArguments: Void.self, tag: context.tag)
     try inContext(contextKey, injectedInProperty: child.label, logErrors: false) {
         try injectedPropertyBox.resolve(self)
     }
@@ -267,7 +267,7 @@ private class _InjectedPropertyBox<T> {
     let tag = overrideTag ? self.tag : container.context.tag
     do {
       container.context.key = container.context.key.tagged(tag)
-      let key = DefinitionKey(protocolType: T.self, argumentsType: Void.self, associatedTag: tag?.dependencyTag)
+      let key = DefinitionKey(type: T.self, typeOfArguments: Void.self, tag: tag?.dependencyTag)
       return try resolve(container, key: key, builder: { factory in try factory() }) as? T
     }
     catch {

--- a/Sources/AutoWiring.swift
+++ b/Sources/AutoWiring.swift
@@ -41,12 +41,12 @@ extension DependencyContainer {
     defer { context.logErrors = shouldLogErrors }
     context.logErrors = false
     
-    guard key.argumentsType == Void.self else {
+    guard key.typeOfArguments == Void.self else {
       throw DipError.DefinitionNotFound(key: key)
     }
     
-    let tag = key.associatedTag
-    let type = key.protocolType
+    let tag = key.tag
+    let type = key.type
     let resolved: Any?
     do {
       let definitions = autoWiringDefinitions(type, tag: tag)
@@ -84,7 +84,7 @@ extension DependencyContainer {
       //If the next definition matches current definition then they are ambigous
       if let nextPair = keyDefinitionPairs[next: index], case keyDefinitionPair = nextPair {
           throw DipError.AmbiguousDefinitions(
-            type: keyDefinitionPair.key.protocolType,
+            type: keyDefinitionPair.key.type,
             definitions: [keyDefinitionPair.definition, nextPair.definition]
         )
       }
@@ -120,19 +120,19 @@ typealias KeyDefinitionPair = (key: DefinitionKey, definition: _Definition)
 
 /// Definitions are matched if they are registered for the same tag and thier factories accept the same number of runtime arguments.
 private func ~=(lhs: KeyDefinitionPair, rhs: KeyDefinitionPair) -> Bool {
-  guard lhs.key.protocolType == rhs.key.protocolType else { return false }
-  guard lhs.key.associatedTag == rhs.key.associatedTag else { return false }
+  guard lhs.key.type == rhs.key.type else { return false }
+  guard lhs.key.tag == rhs.key.tag else { return false }
   guard lhs.definition.numberOfArguments == rhs.definition.numberOfArguments else { return false }
   return true
 }
 
-func filter(definitions: [KeyDefinitionPair], type: Any.Type, tag: DependencyContainer.Tag?, argumentsType: Any.Type? = nil) -> [KeyDefinitionPair] {
+func filter(definitions: [KeyDefinitionPair], type: Any.Type, tag: DependencyContainer.Tag?, typeOfArguments: Any.Type? = nil) -> [KeyDefinitionPair] {
   let definitions =  definitions
-    .filter({ $0.key.protocolType == type || $0.definition.doesImplements(type) })
-    .filter({ $0.key.associatedTag == tag || $0.key.associatedTag == nil })
+    .filter({ $0.key.type == type || $0.definition.doesImplements(type) })
+    .filter({ $0.key.tag == tag || $0.key.tag == nil })
   
-  if let argumentsType = argumentsType {
-    return definitions.filter({ $0.key.argumentsType == argumentsType })
+  if let typeOfArguments = typeOfArguments {
+    return definitions.filter({ $0.key.typeOfArguments == typeOfArguments })
   }
   return definitions
 }
@@ -140,7 +140,7 @@ func filter(definitions: [KeyDefinitionPair], type: Any.Type, tag: DependencyCon
 func order(definitions: [KeyDefinitionPair], tag: DependencyContainer.Tag?) -> [KeyDefinitionPair] {
   return
     //first will try to use tagged definitions
-    definitions.filter({ $0.key.associatedTag == tag }) +
+    definitions.filter({ $0.key.tag == tag }) +
     //then will use not tagged definitions
-    definitions.filter({ $0.key.associatedTag != tag })
+    definitions.filter({ $0.key.tag != tag })
 }

--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -80,6 +80,9 @@ public enum ComponentScope {
    
    ```
    */
+  case Unique
+  
+  @available(*, deprecated=4.6.1, message="Prototype scope is renamed to Unique")
   case Prototype
   
   /**
@@ -92,7 +95,7 @@ public enum ComponentScope {
    **Example**:
    
    ```
-   container.register(.ObjectGraph) { ServiceImp() as Service }
+   container.register(.Shared) { ServiceImp() as Service }
    container.register {
      ServiceConsumerImp(
        service1: try container.resolve() as Service
@@ -106,6 +109,9 @@ public enum ComponentScope {
    consumer1.service1 !== consumer2.service1 //true
    ```
    */
+  case Shared
+  
+  @available(*, deprecated=4.6.1, message="ObjectGraph scope is renamed to Shared")
   case ObjectGraph
 
   /**

--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -24,38 +24,49 @@
 
 ///A key used to store definitons in a container.
 public struct DefinitionKey : Hashable, CustomStringConvertible {
-  public let protocolType: Any.Type
-  public let argumentsType: Any.Type
-  public private(set) var associatedTag: DependencyContainer.Tag?
-  
-  init(protocolType: Any.Type, argumentsType: Any.Type, associatedTag: DependencyContainer.Tag? = nil) {
-    self.protocolType = protocolType
-    self.argumentsType = argumentsType
-    self.associatedTag = associatedTag
+  public let type: Any.Type
+  public let typeOfArguments: Any.Type
+  public private(set) var tag: DependencyContainer.Tag?
+
+  init(type: Any.Type, typeOfArguments: Any.Type, tag: DependencyContainer.Tag? = nil) {
+    self.type = type
+    self.typeOfArguments = typeOfArguments
+    self.tag = tag
   }
   
   public var hashValue: Int {
-    return "\(protocolType)-\(argumentsType)-\(associatedTag)".hashValue
+    return "\(type)-\(typeOfArguments)-\(tag)".hashValue
   }
   
   public var description: String {
-    return "type: \(protocolType), arguments: \(argumentsType), tag: \(associatedTag.desc)"
+    return "type: \(type), arguments: \(typeOfArguments), tag: \(tag.desc)"
   }
   
   func tagged(tag: DependencyContainer.Tag?) -> DefinitionKey {
     var tagged = self
-    tagged.associatedTag = tag
+    tagged.tag = tag
     return tagged
   }
   
 }
 
-/// Check two definition keys on equality by comparing their `protocolType`, `factoryType` and `associatedTag` properties.
+//MARK: - Deprecated
+extension DefinitionKey {
+  
+  @available(*, deprecated=4.6.1, message="Property protocolType was renamed to type")
+  public var protocolType: Any.Type { return type }
+  @available(*, deprecated=4.6.1, message="Property argumentsType was renamed to typeOfArguments")
+  public var argumentsType: Any.Type { return typeOfArguments }
+  @available(*, deprecated=4.6.1, message="Property associatedTag was renamed to tag")
+  public var associatedTag: DependencyContainer.Tag? { return tag }
+}
+
+/// Check two definition keys on equality by comparing their `type`, `factoryType` and `tag` properties.
 public func ==(lhs: DefinitionKey, rhs: DefinitionKey) -> Bool {
   return
-    lhs.protocolType == rhs.protocolType &&
-      lhs.argumentsType == rhs.argumentsType &&
-      lhs.associatedTag == rhs.associatedTag
+    lhs.type == rhs.type &&
+      lhs.typeOfArguments == rhs.typeOfArguments &&
+      lhs.tag == rhs.tag
 }
 
 ///Component scope defines a strategy used by the `DependencyContainer` to manage resolved instances life cycle.

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -135,7 +135,7 @@ extension DependencyContainer {
    container.register {
      //container will pass through the tag ("tag") used to resolve SomeService to resolve $0
      SomeServiceImp(dependency: $0) as SomeService
-   }.resolveDependencies { container, service in
+   }.resolvingProperties { container, service in
      //container will use `nil` tag to resolve this dependency
      self.dependency = try container.resolve() as SomeDependency
    
@@ -483,7 +483,7 @@ extension DependencyContainer {
     }
 
     try autoInjectProperties(resolvedInstance)
-    try definition.resolveDependenciesOf(resolvedInstance, withContainer: self)
+    try definition.resolveProperties(instance: resolvedInstance, container: self)
     
     log(.Verbose, "Resolved type \(key.type) with \(resolvedInstance)")
     return resolvedInstance

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -267,7 +267,7 @@ extension DependencyContainer {
    container.register { try ClientImp(service: container.resolve() as Service) as Client }
    ```
    */
-  public func register<T>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Unique, factory: () throws -> T) -> DefinitionOf<T, () throws -> T> {
+  public func register<T>(scope: ComponentScope = .Unique, tag: DependencyTagConvertible? = nil, factory: () throws -> T) -> DefinitionOf<T, () throws -> T> {
     let definition = DefinitionBuilder<T, ()> {
       $0.scope = scope
       $0.factory = factory

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -263,11 +263,11 @@ extension DependencyContainer {
    ```swift
    container.register { ServiceImp() as Service }
    container.register(tag: "service") { ServiceImp() as Service }
-   container.register(.ObjectGraph) { ServiceImp() as Service }
+   container.register(.Shared) { ServiceImp() as Service }
    container.register { try ClientImp(service: container.resolve() as Service) as Client }
    ```
    */
-  public func register<T>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Prototype, factory: () throws -> T) -> DefinitionOf<T, () throws -> T> {
+  public func register<T>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Unique, factory: () throws -> T) -> DefinitionOf<T, () throws -> T> {
     let definition = DefinitionBuilder<T, ()> {
       $0.scope = scope
       $0.factory = factory
@@ -293,7 +293,7 @@ extension DependencyContainer {
    than _Dip_ supports (currently it's up to six) like in the following example:
    
    ```swift
-   public func register<T, A, B, C, ...>(tag: Tag? = nil, scope: ComponentScope = .Prototype, factory: (A, B, C, ...) throws -> T) -> DefinitionOf<T, (A, B, C, ...) throws -> T> {
+   public func register<T, A, B, C, ...>(tag: Tag? = nil, scope: ComponentScope = .Unique, factory: (A, B, C, ...) throws -> T) -> DefinitionOf<T, (A, B, C, ...) throws -> T> {
      return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: ...) { container, tag in
         try factory(container.resolve(tag: tag), ...)
       }
@@ -689,16 +689,16 @@ private class ResolvedInstances {
       switch scope {
       case .Singleton, .EagerSingleton: return singletons[key]
       case .WeakSingleton: return (weakSingletons[key] as? WeakBoxType)?.unboxed ?? weakSingletons[key]
-      case .ObjectGraph: return resolvedInstances[key]
-      case .Prototype: return nil
+      case .Shared, .ObjectGraph: return resolvedInstances[key]
+      case .Unique, .Prototype: return nil
       }
     }
     set {
       switch scope {
       case .Singleton, .EagerSingleton: singletons[key] = newValue
       case .WeakSingleton: weakSingletons[key] = newValue
-      case .ObjectGraph: resolvedInstances[key] = newValue
-      case .Prototype: break
+      case .Shared, .ObjectGraph: resolvedInstances[key] = newValue
+      case .Unique, .Prototype: break
       }
     }
   }

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -154,12 +154,12 @@ extension DependencyContainer {
     
     /// Currently resolving type.
     public var resolvingType: Any.Type {
-      return key.protocolType
+      return key.type
     }
 
     /// The tag used to resolve currently resolving type.
     public var tag: Tag? {
-      return key.associatedTag
+      return key.tag
     }
     
     /// The type that caused currently resolving type to be resolved.
@@ -182,7 +182,7 @@ extension DependencyContainer {
     }
     
     public var description: String {
-      let resolvingDescription = "Resolving type \(key.protocolType) with arguments \(key.argumentsType) tagged with \(key.associatedTag.desc)"
+      let resolvingDescription = "Resolving type \(key.type) with arguments \(key.typeOfArguments) tagged with \(key.tag.desc)"
       if injectedInProperty != nil {
         return "\(resolvingDescription) while auto-injecting property \(injectedInProperty.desc) of \(injectedInType.desc)"
       }
@@ -326,7 +326,7 @@ extension DependencyContainer {
     precondition(!bootstrapped, "You can not modify container's definitions after it was bootstrapped.")
     
     threadSafe {
-      let key = DefinitionKey(protocolType: T.self, argumentsType: U.self, associatedTag: tag?.dependencyTag)
+      let key = DefinitionKey(type: T.self, typeOfArguments: U.self, tag: tag?.dependencyTag)
       
       definitions[key] = definition
       resolvedInstances.singletons[key] = nil
@@ -425,7 +425,7 @@ extension DependencyContainer {
    - seealso: `resolve(tag:builder:)`
   */
   public func resolve<U>(type: Any.Type, tag: DependencyTagConvertible? = nil, builder: (U throws -> Any) throws -> Any) rethrows -> Any {
-    let key = DefinitionKey(protocolType: type, argumentsType: U.self, associatedTag: tag?.dependencyTag)
+    let key = DefinitionKey(type: type, typeOfArguments: U.self, tag: tag?.dependencyTag)
     
     return try inContext(key) {
       try resolveKey(key, builder: { definition in
@@ -485,13 +485,13 @@ extension DependencyContainer {
     try autoInjectProperties(resolvedInstance)
     try definition.resolveDependenciesOf(resolvedInstance, withContainer: self)
     
-    log(.Verbose, "Resolved type \(key.protocolType) with \(resolvedInstance)")
+    log(.Verbose, "Resolved type \(key.type) with \(resolvedInstance)")
     return resolvedInstance
   }
   
   private func previouslyResolved<T>(definition: _Definition, key: DefinitionKey) -> T? {
     let keys = definition.implementingTypes.map({
-      DefinitionKey(protocolType: $0, argumentsType: key.argumentsType, associatedTag: key.associatedTag)
+      DefinitionKey(type: $0, typeOfArguments: key.typeOfArguments, tag: key.tag)
     })
     for key in [key] + keys {
       if let previouslyResolved = resolvedInstances[forKey: key, inScope: definition.scope] as? T {
@@ -503,7 +503,7 @@ extension DependencyContainer {
   
   /// Searches for definition that matches provided key
   private func definition(matching key: DefinitionKey) -> KeyDefinitionPair? {
-    let typeDefinitions = definitions.filter({ $0.0.protocolType ==  key.protocolType })
+    let typeDefinitions = definitions.filter({ $0.0.type ==  key.type })
     guard !typeDefinitions.isEmpty else {
       return typeForwardingDefinition(key)
     }
@@ -550,8 +550,8 @@ extension DependencyContainer {
         //so there is probably a cercular reference between containers.
         //To break it skip this container
         if let context = collaborator.context where
-          context.resolvingType == key.protocolType &&
-          context.tag == key.associatedTag { continue }
+          context.resolvingType == key.type &&
+          context.tag == key.tag { continue }
 
         //Pass current container's instances pool to collect instances resolved by collaborator
         let resolvedInstances = collaborator.resolvedInstances
@@ -591,7 +591,7 @@ extension DependencyContainer {
       - definition: The definition to remove
    */
   public func remove<T, U>(definition: DefinitionOf<T, U>, forTag tag: DependencyTagConvertible? = nil) {
-    let key = DefinitionKey(protocolType: T.self, argumentsType: U.self, associatedTag: tag?.dependencyTag)
+    let key = DefinitionKey(type: T.self, typeOfArguments: U.self, tag: tag?.dependencyTag)
     remove(definitionForKey: key)
   }
   
@@ -634,7 +634,7 @@ extension DependencyContainer {
     validateNextDefinition: for (key, _) in definitions {
       do {
         //try to resolve key using provided arguments
-        for argumentsSet in arguments where argumentsSet.dynamicType == key.argumentsType {
+        for argumentsSet in arguments where argumentsSet.dynamicType == key.typeOfArguments {
           do {
             try inContext(key) {
               try resolveKey(key, builder: { definition throws -> Any in
@@ -652,7 +652,7 @@ extension DependencyContainer {
         
         //try to resolve key using auto-wiring
         do {
-          try self.resolve(key.protocolType, tag: key.associatedTag)
+          try self.resolve(key.type, tag: key.tag)
         }
         catch let error as DipError {
           throw error
@@ -842,7 +842,7 @@ public enum DipError: ErrorType, CustomStringConvertible {
   public var description: String {
     switch self {
     case let .DefinitionNotFound(key):
-      return "No definition registered for \(key).\nCheck the tag, type you try to resolve, number, order and types of runtime arguments passed to `resolve()` and match them with registered factories for type \(key.protocolType)."
+      return "No definition registered for \(key).\nCheck the tag, type you try to resolve, number, order and types of runtime arguments passed to `resolve()` and match them with registered factories for type \(key.type)."
     case let .AutoInjectionFailed(label, type, error):
       return "Failed to auto-inject property \"\(label.desc)\" of type \(type). \(error)"
     case let .AutoWiringFailed(type, error):

--- a/Sources/RuntimeArguments.swift
+++ b/Sources/RuntimeArguments.swift
@@ -42,7 +42,7 @@ extension DependencyContainer {
   
   - seealso: `registerFactory(tag:scope:factory:)`
   */
-  public func register<T, A>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Unique, factory: (A) throws -> T) -> DefinitionOf<T, (A) throws -> T> {
+  public func register<T, A>(scope: ComponentScope = .Unique, tag: DependencyTagConvertible? = nil, factory: (A) throws -> T) -> DefinitionOf<T, (A) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 1) { container, tag in try factory(container.resolve(tag: tag)) }
   }
   
@@ -82,7 +82,7 @@ extension DependencyContainer {
   // MARK: 2 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, A, B>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Unique, factory: (A, B) throws -> T) -> DefinitionOf<T, (A, B) throws -> T> {
+  public func register<T, A, B>(scope: ComponentScope = .Unique, tag: DependencyTagConvertible? = nil, factory: (A, B) throws -> T) -> DefinitionOf<T, (A, B) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 2) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   
@@ -99,7 +99,7 @@ extension DependencyContainer {
   // MARK: 3 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, A, B, C>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Unique, factory: (A, B, C) throws -> T) -> DefinitionOf<T, (A, B, C) throws -> T> {
+  public func register<T, A, B, C>(scope: ComponentScope = .Unique, tag: DependencyTagConvertible? = nil, factory: (A, B, C) throws -> T) -> DefinitionOf<T, (A, B, C) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 3)  { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   
@@ -116,7 +116,7 @@ extension DependencyContainer {
   // MARK: 4 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, A, B, C, D>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Unique, factory: (A, B, C, D) throws -> T) -> DefinitionOf<T, (A, B, C, D) throws -> T> {
+  public func register<T, A, B, C, D>(scope: ComponentScope = .Unique, tag: DependencyTagConvertible? = nil, factory: (A, B, C, D) throws -> T) -> DefinitionOf<T, (A, B, C, D) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 4) { container, tag in try factory(container.resolve(tag: tag),  container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   
@@ -133,7 +133,7 @@ extension DependencyContainer {
   // MARK: 5 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, A, B, C, D, E>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Unique, factory: (A, B, C, D, E) throws -> T) -> DefinitionOf<T, (A, B, C, D, E) throws -> T> {
+  public func register<T, A, B, C, D, E>(scope: ComponentScope = .Unique, tag: DependencyTagConvertible? = nil, factory: (A, B, C, D, E) throws -> T) -> DefinitionOf<T, (A, B, C, D, E) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 5) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   
@@ -150,7 +150,7 @@ extension DependencyContainer {
   // MARK: 6 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, A, B, C, D, E, F>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Unique, factory: (A, B, C, D, E, F) throws -> T) -> DefinitionOf<T, (A, B, C, D, E, F) throws -> T> {
+  public func register<T, A, B, C, D, E, F>(scope: ComponentScope = .Unique, tag: DependencyTagConvertible? = nil, factory: (A, B, C, D, E, F) throws -> T) -> DefinitionOf<T, (A, B, C, D, E, F) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 6) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   

--- a/Sources/RuntimeArguments.swift
+++ b/Sources/RuntimeArguments.swift
@@ -70,12 +70,12 @@ extension DependencyContainer {
 
    - seealso: `register(tag:_:factory:)`, `resolve(tag:builder:)`
    */
-  public func resolve<T, A>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: A) throws -> T {
+  public func resolve<T, A>(tag tag: DependencyTagConvertible? = nil, arguments arg1: A) throws -> T {
     return try resolve(tag: tag) { factory in try factory(arg1) }
   }
 
   ///- seealso: `resolve(_:tag:)`, `resolve(tag:withArguments:)`
-  public func resolve<A>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A) throws -> Any {
+  public func resolve<A>(type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A) throws -> Any {
     return try resolve(type, tag: tag) { factory in try factory(arg1) }
   }
 
@@ -87,15 +87,15 @@ extension DependencyContainer {
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
-  public func resolve<T, A, B>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B) throws -> T {
+  public func resolve<T, A, B>(tag tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B) throws -> T {
     return try resolve(tag: tag) { factory in try factory(arg1, arg2) }
   }
   
   ///- seealso: `resolve(_:tag:)`, `resolve(tag:withArguments:)`
-  public func resolve<A, B>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B) throws -> Any {
+  public func resolve<A, B>(type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B) throws -> Any {
     return try resolve(type, tag: tag) { factory in try factory((arg1, arg2)) }
   }
-
+  
   // MARK: 3 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
@@ -104,15 +104,15 @@ extension DependencyContainer {
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
-  public func resolve<T, A, B, C>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C) throws -> T {
+  public func resolve<T, A, B, C>(tag tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C) throws -> T {
     return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3) }
   }
   
   ///- seealso: `resolve(_:tag:)`, `resolve(tag:withArguments:)`
-  public func resolve<A, B, C>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C) throws -> Any {
+  public func resolve<A, B, C>(type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C) throws -> Any {
     return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3)) }
   }
-  
+
   // MARK: 4 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
@@ -121,12 +121,12 @@ extension DependencyContainer {
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
-  public func resolve<T, A, B, C, D>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D) throws -> T {
+  public func resolve<T, A, B, C, D>(tag tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D) throws -> T {
     return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3, arg4) }
   }
 
   /// - seealso: `resolve(_:tag:)`, `resolve(tag:withArguments:)`
-  public func resolve<A, B, C, D>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D) throws -> Any {
+  public func resolve<A, B, C, D>(type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D) throws -> Any {
     return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3, arg4)) }
   }
 
@@ -138,12 +138,12 @@ extension DependencyContainer {
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
-  public func resolve<T, A, B, C, D, E>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E) throws -> T {
+  public func resolve<T, A, B, C, D, E>(tag tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E) throws -> T {
     return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3, arg4, arg5) }
   }
 
   ///- seealso: `resolve(_:tag:)`, `resolve(tag:withArguments:)`
-  public func resolve<A, B, C, D, E>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E) throws -> Any {
+  public func resolve<A, B, C, D, E>(type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E) throws -> Any {
     return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3, arg4, arg5)) }
   }
 
@@ -155,14 +155,80 @@ extension DependencyContainer {
   }
   
   /// - seealso: `resolve(tag:withArguments:)`
-  public func resolve<T, A, B, C, D, E, F>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E, _ arg6: F) throws -> T {
+  public func resolve<T, A, B, C, D, E, F>(tag tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E, _ arg6: F) throws -> T {
     return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3, arg4, arg5, arg6) }
   }
 
   /// - seealso: `resolve(_:tag:)`, `resolve(tag:withArguments:)`
-  public func resolve<A, B, C, D, E, F>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E, _ arg6: F) throws -> Any {
+  public func resolve<A, B, C, D, E, F>(type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E, _ arg6: F) throws -> Any {
     return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3, arg4, arg5, arg6)) }
   }
 
+}
+
+//MARK - Deprecated methods
+
+extension DependencyContainer {
+  
+  @available(*, deprecated=4.6.1, message="Use resolve(tag:arguments:) instead")
+  public func resolve<T, A>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: A) throws -> T {
+    return try resolve(tag: tag) { factory in try factory(arg1) }
+  }
+  
+  @available(*, deprecated=4.6.1, message="Use resolve(_:tag:arguments:) instead")
+  public func resolve<A>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A) throws -> Any {
+    return try resolve(type, tag: tag) { factory in try factory(arg1) }
+  }
+  
+  @available(*, deprecated=4.6.1, message="Use resolve(tag:arguments:_:) instead")
+  public func resolve<T, A, B>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B) throws -> T {
+    return try resolve(tag: tag) { factory in try factory(arg1, arg2) }
+  }
+  
+  @available(*, deprecated=4.6.1, message="Use resolve(_:tag:arguments:_:) instead")
+  public func resolve<A, B>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B) throws -> Any {
+    return try resolve(type, tag: tag) { factory in try factory((arg1, arg2)) }
+  }
+  
+  @available(*, deprecated=4.6.1, message="Use resolve(tag:arguments:_:_:) instead")
+  public func resolve<T, A, B, C>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C) throws -> T {
+    return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3) }
+  }
+  
+  @available(*, deprecated=4.6.1, message="Use resolve(_:tag:arguments:_:_:) instead")
+  public func resolve<A, B, C>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C) throws -> Any {
+    return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3)) }
+  }
+  
+  @available(*, deprecated=4.6.1, message="Use resolve(tag:arguments:_:_:_:) instead")
+  public func resolve<T, A, B, C, D>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D) throws -> T {
+    return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3, arg4) }
+  }
+  
+  @available(*, deprecated=4.6.1, message="Use resolve(_:tag:arguments:_:_:_:) instead")
+  public func resolve<A, B, C, D>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D) throws -> Any {
+    return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3, arg4)) }
+  }
+
+  @available(*, deprecated=4.6.1, message="Use resolve(tag:arguments:_:_:_:_:) instead")
+  public func resolve<T, A, B, C, D, E>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E) throws -> T {
+    return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3, arg4, arg5) }
+  }
+  
+  @available(*, deprecated=4.6.1, message="Use resolve(_: tag:arguments:_:_:_:_:) instead")
+  public func resolve<A, B, C, D, E>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E) throws -> Any {
+    return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3, arg4, arg5)) }
+  }
+  
+  @available(*, deprecated=4.6.1, message="Use resolve(tag:arguments:_:_:_:_:_:) instead")
+  public func resolve<T, A, B, C, D, E, F>(tag tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E, _ arg6: F) throws -> T {
+    return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3, arg4, arg5, arg6) }
+  }
+  
+  @available(*, deprecated=4.6.1, message="Use resolve(_:tag:arguments:_:_:_:_:_:) instead")
+  public func resolve<A, B, C, D, E, F>(type: Any.Type, tag: DependencyTagConvertible? = nil, withArguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E, _ arg6: F) throws -> Any {
+    return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3, arg4, arg5, arg6)) }
+  }
+  
 }
 

--- a/Sources/RuntimeArguments.swift
+++ b/Sources/RuntimeArguments.swift
@@ -37,12 +37,12 @@ extension DependencyContainer {
 
   - parameters:
     - tag: The arbitrary tag to associate this factory with. Pass `nil` to associate with any tag. Default value is `nil`.
-    - scope: The scope to use for this component. Default value is `.Prototype`.
+    - scope: The scope to use for this component. Default value is `.Unique`.
     - factory: The factory to register.
   
   - seealso: `registerFactory(tag:scope:factory:)`
   */
-  public func register<T, A>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Prototype, factory: (A) throws -> T) -> DefinitionOf<T, (A) throws -> T> {
+  public func register<T, A>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Unique, factory: (A) throws -> T) -> DefinitionOf<T, (A) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 1) { container, tag in try factory(container.resolve(tag: tag)) }
   }
   
@@ -82,7 +82,7 @@ extension DependencyContainer {
   // MARK: 2 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, A, B>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Prototype, factory: (A, B) throws -> T) -> DefinitionOf<T, (A, B) throws -> T> {
+  public func register<T, A, B>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Unique, factory: (A, B) throws -> T) -> DefinitionOf<T, (A, B) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 2) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   
@@ -99,7 +99,7 @@ extension DependencyContainer {
   // MARK: 3 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, A, B, C>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Prototype, factory: (A, B, C) throws -> T) -> DefinitionOf<T, (A, B, C) throws -> T> {
+  public func register<T, A, B, C>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Unique, factory: (A, B, C) throws -> T) -> DefinitionOf<T, (A, B, C) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 3)  { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   
@@ -116,7 +116,7 @@ extension DependencyContainer {
   // MARK: 4 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, A, B, C, D>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Prototype, factory: (A, B, C, D) throws -> T) -> DefinitionOf<T, (A, B, C, D) throws -> T> {
+  public func register<T, A, B, C, D>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Unique, factory: (A, B, C, D) throws -> T) -> DefinitionOf<T, (A, B, C, D) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 4) { container, tag in try factory(container.resolve(tag: tag),  container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   
@@ -133,7 +133,7 @@ extension DependencyContainer {
   // MARK: 5 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, A, B, C, D, E>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Prototype, factory: (A, B, C, D, E) throws -> T) -> DefinitionOf<T, (A, B, C, D, E) throws -> T> {
+  public func register<T, A, B, C, D, E>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Unique, factory: (A, B, C, D, E) throws -> T) -> DefinitionOf<T, (A, B, C, D, E) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 5) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   
@@ -150,7 +150,7 @@ extension DependencyContainer {
   // MARK: 6 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, A, B, C, D, E, F>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Prototype, factory: (A, B, C, D, E, F) throws -> T) -> DefinitionOf<T, (A, B, C, D, E, F) throws -> T> {
+  public func register<T, A, B, C, D, E, F>(tag tag: DependencyTagConvertible? = nil, _ scope: ComponentScope = .Unique, factory: (A, B, C, D, E, F) throws -> T) -> DefinitionOf<T, (A, B, C, D, E, F) throws -> T> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 6) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   

--- a/Sources/TypeForwarding.swift
+++ b/Sources/TypeForwarding.swift
@@ -77,8 +77,8 @@ extension DependencyContainer {
   func typeForwardingDefinition(key: DefinitionKey) -> KeyDefinitionPair? {
     var forwardingDefinitions = self.definitions.map({ (key: $0.0, definition: $0.1) })
     
-    forwardingDefinitions = filter(forwardingDefinitions, type: key.type, tag: key.tag, typeOfArguments: key.typeOfArguments)
-    forwardingDefinitions = order(forwardingDefinitions, tag: key.tag)
+    forwardingDefinitions = filter(forwardingDefinitions, byKeyAndTypeOfArguments: key)
+    forwardingDefinitions = order(forwardingDefinitions, byTag: key.tag)
 
     //we need to carry on original tag
     return forwardingDefinitions.first.map({ ($0.key.tagged(key.tag), $0.definition) })

--- a/Sources/TypeForwarding.swift
+++ b/Sources/TypeForwarding.swift
@@ -43,7 +43,7 @@ extension DependencyContainer {
    - returns: New definition for passed type.
    */
   public func register<T, U, F>(definition: DefinitionOf<T, U throws -> T>, type: F.Type, tag: DependencyTagConvertible? = nil) -> DefinitionOf<F, U throws -> F> {
-    let key = DefinitionKey(protocolType: F.self, argumentsType: U.self)
+    let key = DefinitionKey(type: F.self, typeOfArguments: U.self)
     
     let forwardDefinition = DefinitionBuilder<F, U> {
       $0.scope = definition.scope
@@ -77,11 +77,11 @@ extension DependencyContainer {
   func typeForwardingDefinition(key: DefinitionKey) -> KeyDefinitionPair? {
     var forwardingDefinitions = self.definitions.map({ (key: $0.0, definition: $0.1) })
     
-    forwardingDefinitions = filter(forwardingDefinitions, type: key.protocolType, tag: key.associatedTag, argumentsType: key.argumentsType)
-    forwardingDefinitions = order(forwardingDefinitions, tag: key.associatedTag)
+    forwardingDefinitions = filter(forwardingDefinitions, type: key.type, tag: key.tag, typeOfArguments: key.typeOfArguments)
+    forwardingDefinitions = order(forwardingDefinitions, tag: key.tag)
 
     //we need to carry on original tag
-    return forwardingDefinitions.first.map({ ($0.key.tagged(key.associatedTag), $0.definition) })
+    return forwardingDefinitions.first.map({ ($0.key.tagged(key.tag), $0.definition) })
   }
   
 }

--- a/Tests/Dip/AutoInjectionTests.swift
+++ b/Tests/Dip/AutoInjectionTests.swift
@@ -120,8 +120,8 @@ class AutoInjectionTests: XCTestCase {
   #endif
 
   func testThatItResolvesAutoInjectedDependencies() {
-    container.register(.ObjectGraph) { ServerImp() as Server }
-    container.register(.ObjectGraph) { ClientImp() as Client }
+    container.register(.Shared) { ServerImp() as Server }
+    container.register(.Shared) { ClientImp() as Client }
     
     let client = try! container.resolve() as Client
     let server = client.server
@@ -129,8 +129,8 @@ class AutoInjectionTests: XCTestCase {
   }
   
   func testThatItCanSetInjectedProperty() {
-    container.register(.ObjectGraph) { ServerImp() as Server }
-    container.register(.ObjectGraph) { ClientImp() as Client }
+    container.register(.Shared) { ServerImp() as Server }
+    container.register(.Shared) { ClientImp() as Client }
     
     let client = (try! container.resolve() as Client) as! ClientImp
     let server = client.server as! ServerImp
@@ -145,7 +145,7 @@ class AutoInjectionTests: XCTestCase {
   }
   
   func testThatItThrowsErrorIfFailsToAutoInjectDependency() {
-    container.register(.ObjectGraph) { ClientImp() as Client }
+    container.register(.Shared) { ClientImp() as Client }
     
     AssertThrows(expression: try container.resolve() as Client)
   }
@@ -172,13 +172,13 @@ class AutoInjectionTests: XCTestCase {
     var serverBlockWasCalled = false
     
     //given
-    container.register(.ObjectGraph) { ServerImp() as Server }
+    container.register(.Shared) { ServerImp() as Server }
       .resolveDependencies { (container, server) -> () in
         serverBlockWasCalled = true
     }
 
     var clientBlockWasCalled = false
-    container.register(.ObjectGraph) { ClientImp() as Client }
+    container.register(.Shared) { ClientImp() as Client }
       .resolveDependencies { (container, client) -> () in
         clientBlockWasCalled = true
     }
@@ -193,12 +193,12 @@ class AutoInjectionTests: XCTestCase {
   
   func testThatItReusesResolvedAutoInjectedInstances() {
     //given
-    container.register(.ObjectGraph) { ServerImp() as Server }
+    container.register(.Shared) { ServerImp() as Server }
       .resolveDependencies { (container, server) -> () in
         server.anotherClient = try! container.resolve() as Client
     }
 
-    container.register(.ObjectGraph) { ClientImp() as Client }
+    container.register(.Shared) { ClientImp() as Client }
       .resolveDependencies { (container, client) -> () in
         client.anotherServer = try! container.resolve() as Server
     }
@@ -221,9 +221,9 @@ class AutoInjectionTests: XCTestCase {
   
   func testThatItReusesAutoInjectedInstancesOnNextResolveOrAutoInjection() {
     //given
-    container.register(.ObjectGraph) { Obj1() }
-    container.register(.ObjectGraph) { Obj2() }
-    container.register(.ObjectGraph) { Obj3(obj: try self.container.resolve()) }
+    container.register(.Shared) { Obj1() }
+    container.register(.Shared) { Obj2() }
+    container.register(.Shared) { Obj3(obj: try self.container.resolve()) }
     
     //when
     let obj2 = try! container.resolve() as Obj2
@@ -238,8 +238,8 @@ class AutoInjectionTests: XCTestCase {
   
   func testThatThereIsNoRetainCycleBetweenAutoInjectedCircularDependencies() {
     //given
-    container.register(.ObjectGraph) { ServerImp() as Server }
-    container.register(.ObjectGraph) { ClientImp() as Client }
+    container.register(.Shared) { ServerImp() as Server }
+    container.register(.Shared) { ClientImp() as Client }
 
     //when
     var client: Client? = try! container.resolve() as Client
@@ -262,8 +262,8 @@ class AutoInjectionTests: XCTestCase {
     AutoInjectionTests.serverDidInjectCalled = false
     
     //given
-    container.register(.ObjectGraph) { ServerImp() as Server }
-    container.register(.ObjectGraph) { ClientImp() as Client }
+    container.register(.Shared) { ServerImp() as Server }
+    container.register(.Shared) { ClientImp() as Client }
     
     //when
     try! container.resolve() as Client
@@ -275,17 +275,17 @@ class AutoInjectionTests: XCTestCase {
   
   func testThatNoErrorThrownWhenOptionalPropertiesAreNotAutoInjected() {
     //given
-    container.register(.ObjectGraph) { ServerImp() as Server }
-    container.register(.ObjectGraph) { ClientImp() as Client }
+    container.register(.Shared) { ServerImp() as Server }
+    container.register(.Shared) { ClientImp() as Client }
 
     AssertNoThrow(expression: try container.resolve() as Client, "Container should not throw error if failed to resolve optional auto-injected properties.")
   }
   
   func testThatItResolvesTaggedAutoInjectedProperties() {
     //given
-    container.register(.ObjectGraph) { ServerImp() as Server }
-    container.register(tag: "tagged", .ObjectGraph) { ServerImp() as Server }
-    container.register(.ObjectGraph) { ClientImp() as Client }
+    container.register(.Shared) { ServerImp() as Server }
+    container.register(tag: "tagged", .Shared) { ServerImp() as Server }
+    container.register(.Shared) { ClientImp() as Client }
     
     //when
     let client = try! container.resolve() as Client
@@ -302,9 +302,9 @@ class AutoInjectionTests: XCTestCase {
   
   func testThatItPassesTagToAutoInjectedProperty() {
     //given
-    container.register(.ObjectGraph) { ServerImp() as Server }
-    container.register(tag: "tagged", .ObjectGraph) { ServerImp() as Server }
-    container.register(.ObjectGraph) { ClientImp() as Client }
+    container.register(.Shared) { ServerImp() as Server }
+    container.register(tag: "tagged", .Shared) { ServerImp() as Server }
+    container.register(.Shared) { ClientImp() as Client }
     
     //when
     let client = try! container.resolve(tag: "tagged") as Client
@@ -319,10 +319,10 @@ class AutoInjectionTests: XCTestCase {
   
   func testThatItDoesNotPassTagToAutoInjectedPropertyWithExplicitTag() {
     //given
-    container.register(.ObjectGraph) { ServerImp() as Server }
-    container.register(tag: "tagged", .ObjectGraph) { ServerImp() as Server }
+    container.register(.Shared) { ServerImp() as Server }
+    container.register(tag: "tagged", .Shared) { ServerImp() as Server }
 
-    container.register(.ObjectGraph) { ClientImp() as Client }
+    container.register(.Shared) { ClientImp() as Client }
       .resolveDependencies { (container, client) -> () in
         client.anotherServer = try! container.resolve() as Server
     }
@@ -346,8 +346,8 @@ class AutoInjectionTests: XCTestCase {
   
   func testThatItAutoInjectsPropertyWithCollaboratingContainer() {
     let collaborator = DependencyContainer()
-    collaborator.register(.ObjectGraph) { ServerImp() as Server }
-    container.register(.ObjectGraph) { ClientImp() as Client }
+    collaborator.register(.Shared) { ServerImp() as Server }
+    container.register(.Shared) { ClientImp() as Client }
     
     container.collaborate(with: collaborator)
     collaborator.collaborate(with: container)

--- a/Tests/Dip/AutoInjectionTests.swift
+++ b/Tests/Dip/AutoInjectionTests.swift
@@ -173,13 +173,13 @@ class AutoInjectionTests: XCTestCase {
     
     //given
     container.register(.Shared) { ServerImp() as Server }
-      .resolveDependencies { (container, server) -> () in
+      .resolvingProperties { (container, server) -> () in
         serverBlockWasCalled = true
     }
 
     var clientBlockWasCalled = false
     container.register(.Shared) { ClientImp() as Client }
-      .resolveDependencies { (container, client) -> () in
+      .resolvingProperties { (container, client) -> () in
         clientBlockWasCalled = true
     }
 
@@ -194,12 +194,12 @@ class AutoInjectionTests: XCTestCase {
   func testThatItReusesResolvedAutoInjectedInstances() {
     //given
     container.register(.Shared) { ServerImp() as Server }
-      .resolveDependencies { (container, server) -> () in
+      .resolvingProperties { (container, server) -> () in
         server.anotherClient = try! container.resolve() as Client
     }
 
     container.register(.Shared) { ClientImp() as Client }
-      .resolveDependencies { (container, client) -> () in
+      .resolvingProperties { (container, client) -> () in
         client.anotherServer = try! container.resolve() as Server
     }
 
@@ -323,7 +323,7 @@ class AutoInjectionTests: XCTestCase {
     container.register(tag: "tagged", .Shared) { ServerImp() as Server }
 
     container.register(.Shared) { ClientImp() as Client }
-      .resolveDependencies { (container, client) -> () in
+      .resolvingProperties { (container, client) -> () in
         client.anotherServer = try! container.resolve() as Server
     }
 

--- a/Tests/Dip/AutoWiringTests.swift
+++ b/Tests/Dip/AutoWiringTests.swift
@@ -116,7 +116,7 @@ class AutoWiringTests: XCTestCase {
     //2 args
     var factoryWithMostNumberOfArgumentsCalled = false
     container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
-      .resolveDependencies { _ in
+      .resolvingProperties { _ in
         factoryWithMostNumberOfArgumentsCalled = true
     }
     
@@ -168,7 +168,7 @@ class AutoWiringTests: XCTestCase {
     container.register(tag: "tag", .Shared) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
     
     //2 arg tagged
-    container.register(tag: "tag", .Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }.resolveDependencies { _ in
+    container.register(tag: "tag", .Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }.resolvingProperties { _ in
       taggedFactoryWithMostNumberOfArgumentsCalled = true
     }
 
@@ -187,7 +187,7 @@ class AutoWiringTests: XCTestCase {
     
     //1 arg
     var notTaggedFactoryWithMostNumberOfArgumentsCalled = false
-    container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }.resolveDependencies {_ in
+    container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }.resolvingProperties { _ in
       notTaggedFactoryWithMostNumberOfArgumentsCalled = true
     }
     
@@ -219,7 +219,7 @@ class AutoWiringTests: XCTestCase {
   func testThatItDoesNotUseAutoWiringWhenFailedToResolveLowLevelDependency() {
     //given
     container.register(.Shared) { AutoWiredClientImp() as AutoWiredClient }
-      .resolveDependencies { container, resolved in
+      .resolvingProperties { container, resolved in
         resolved.service1 = try container.resolve() as Service
         resolved.service2 = try container.resolve() as ServiceImp2
         
@@ -228,7 +228,7 @@ class AutoWiringTests: XCTestCase {
     }
     
     container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
-      .resolveDependencies { container, resolved in
+      .resolvingProperties { container, resolved in
         //auto-wiring should be performed only when definition for type to resolve is not found
         //but not for any other type along the way in the graph
         XCTFail("Auto-wiring should not be performed if instance was actually resolved.")
@@ -251,7 +251,7 @@ class AutoWiringTests: XCTestCase {
     var anotherInstance: AutoWiredClient?
     
     container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
-      .resolveDependencies { container, _ in
+      .resolvingProperties { container, _ in
         if anotherInstance == nil {
           anotherInstance = try! container.resolve() as AutoWiredClient
         }
@@ -274,7 +274,7 @@ class AutoWiringTests: XCTestCase {
     var anotherInstance: AutoWiredClient?
     
     container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
-      .resolveDependencies { container, _ in
+      .resolvingProperties { container, _ in
         if anotherInstance == nil {
           anotherInstance = try! container.resolve() as AutoWiredClient
         }
@@ -299,7 +299,7 @@ class AutoWiringTests: XCTestCase {
     var anotherInstance: AutoWiredClient?
     
     container.register(tag: "tag", .Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
-      .resolveDependencies { container, _ in
+      .resolvingProperties { container, _ in
         if anotherInstance == nil {
           anotherInstance = try! container.resolve(tag: "tag") as AutoWiredClient
         }
@@ -322,7 +322,7 @@ class AutoWiringTests: XCTestCase {
     var anotherInstance: AutoWiredClient?
     
     container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
-      .resolveDependencies { container, _ in
+      .resolvingProperties { container, _ in
         if anotherInstance == nil {
           anotherInstance = try! container.resolve() as AutoWiredClient
         }

--- a/Tests/Dip/AutoWiringTests.swift
+++ b/Tests/Dip/AutoWiringTests.swift
@@ -212,7 +212,7 @@ class AutoWiringTests: XCTestCase {
     
     //when
     let service = try! container.resolve() as Service
-    AssertThrows(expression: try container.resolve(withArguments: service) as AutoWiredClient,
+    AssertThrows(expression: try container.resolve(arguments: service) as AutoWiredClient,
       "Container should not use auto-wiring when resolving with runtime arguments")
   }
   
@@ -283,7 +283,7 @@ class AutoWiringTests: XCTestCase {
     //when
     let service1 = try! container.resolve() as Service?
     let service2 = try! container.resolve() as ServiceImp2
-    let resolved = try! container.resolve(withArguments: service1, service2) as AutoWiredClient
+    let resolved = try! container.resolve(arguments: service1, service2) as AutoWiredClient
     
     //then
     //when doing another auto-wiring during resolve we should reuse instance

--- a/Tests/Dip/AutoWiringTests.swift
+++ b/Tests/Dip/AutoWiringTests.swift
@@ -84,10 +84,10 @@ class AutoWiringTests: XCTestCase {
 
   func testThatItCanResolveWithAutoWiring() {
     //given
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(.ObjectGraph) { ServiceImp2() }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(.Shared) { ServiceImp2() }
     
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+    container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
     
     //when
     let client = try! container.resolve() as AutoWiredClient
@@ -109,19 +109,19 @@ class AutoWiringTests: XCTestCase {
     //given
     
     //1 arg
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
+    container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
     //1 arg
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: try self.container.resolve(), service2: $0) as AutoWiredClient }
+    container.register(.Shared) { AutoWiredClientImp(service1: try self.container.resolve(), service2: $0) as AutoWiredClient }
     
     //2 args
     var factoryWithMostNumberOfArgumentsCalled = false
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+    container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
       .resolveDependencies { _ in
         factoryWithMostNumberOfArgumentsCalled = true
     }
     
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(.ObjectGraph) { ServiceImp2() }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(.Shared) { ServiceImp2() }
     
     //when
     let _ = try! container.resolve() as AutoWiredClient
@@ -134,12 +134,12 @@ class AutoWiringTests: XCTestCase {
     //given
     
     //1 arg
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
+    container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
     //1 arg
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: try self.container.resolve(), service2: $0) as AutoWiredClient }
+    container.register(.Shared) { AutoWiredClientImp(service1: try self.container.resolve(), service2: $0) as AutoWiredClient }
     
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(.ObjectGraph) { ServiceImp2() }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(.Shared) { ServiceImp2() }
     
     //when
     AssertThrows(expression: try container.resolve() as AutoWiredClient) { error -> Bool in
@@ -156,24 +156,24 @@ class AutoWiringTests: XCTestCase {
     //given
     
     //1 arg
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
+    container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
     //1 arg
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: try self.container.resolve(), service2: $0) as AutoWiredClient }
+    container.register(.Shared) { AutoWiredClientImp(service1: try self.container.resolve(), service2: $0) as AutoWiredClient }
     
     //2 args
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+    container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
     
     //1 arg tagged
     var taggedFactoryWithMostNumberOfArgumentsCalled = false
-    container.register(tag: "tag", .ObjectGraph) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
+    container.register(tag: "tag", .Shared) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
     
     //2 arg tagged
-    container.register(tag: "tag", .ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }.resolveDependencies { _ in
+    container.register(tag: "tag", .Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }.resolveDependencies { _ in
       taggedFactoryWithMostNumberOfArgumentsCalled = true
     }
 
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(.ObjectGraph) { ServiceImp2() }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(.Shared) { ServiceImp2() }
     
     //when
     let _ = try! container.resolve(tag: "tag") as AutoWiredClient
@@ -187,15 +187,15 @@ class AutoWiringTests: XCTestCase {
     
     //1 arg
     var notTaggedFactoryWithMostNumberOfArgumentsCalled = false
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }.resolveDependencies {_ in
+    container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }.resolveDependencies {_ in
       notTaggedFactoryWithMostNumberOfArgumentsCalled = true
     }
     
     //1 arg tagged
-    container.register(tag: "tag", .ObjectGraph) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
+    container.register(tag: "tag", .Shared) { AutoWiredClientImp(service1: $0, service2: try self.container.resolve()) as AutoWiredClient }
     
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(.ObjectGraph) { ServiceImp2() }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(.Shared) { ServiceImp2() }
     
     //when
     let _ = try! container.resolve(tag: "other tag") as AutoWiredClient
@@ -206,9 +206,9 @@ class AutoWiringTests: XCTestCase {
   
   func testThatItDoesNotTryToUseAutoWiringWhenCallingResolveWithArguments() {
     //given
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(.ObjectGraph) { ServiceImp2() }
+    container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(.Shared) { ServiceImp2() }
     
     //when
     let service = try! container.resolve() as Service
@@ -218,7 +218,7 @@ class AutoWiringTests: XCTestCase {
   
   func testThatItDoesNotUseAutoWiringWhenFailedToResolveLowLevelDependency() {
     //given
-    container.register(.ObjectGraph) { AutoWiredClientImp() as AutoWiredClient }
+    container.register(.Shared) { AutoWiredClientImp() as AutoWiredClient }
       .resolveDependencies { container, resolved in
         resolved.service1 = try container.resolve() as Service
         resolved.service2 = try container.resolve() as ServiceImp2
@@ -227,15 +227,15 @@ class AutoWiringTests: XCTestCase {
         throw DipError.DefinitionNotFound(key: DefinitionKey(protocolType: ServiceImp1.self, argumentsType: Any.self))
     }
     
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+    container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
       .resolveDependencies { container, resolved in
         //auto-wiring should be performed only when definition for type to resolve is not found
         //but not for any other type along the way in the graph
         XCTFail("Auto-wiring should not be performed if instance was actually resolved.")
     }
     
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(.ObjectGraph) { ServiceImp2() }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(.Shared) { ServiceImp2() }
     
     //then
     AssertThrows(expression: try container.resolve() as AutoWiredClient,
@@ -245,12 +245,12 @@ class AutoWiringTests: XCTestCase {
   func testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgain() {
     
     //given
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(.ObjectGraph) { ServiceImp2() }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(.Shared) { ServiceImp2() }
     
     var anotherInstance: AutoWiredClient?
     
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+    container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
       .resolveDependencies { container, _ in
         if anotherInstance == nil {
           anotherInstance = try! container.resolve() as AutoWiredClient
@@ -268,12 +268,12 @@ class AutoWiringTests: XCTestCase {
   func testThatItReusesInstancesResolvedWithoutAutoWiringWhenUsingAutoWiringAgain() {
     
     //given
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(.ObjectGraph) { ServiceImp2() }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(.Shared) { ServiceImp2() }
     
     var anotherInstance: AutoWiredClient?
     
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+    container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
       .resolveDependencies { container, _ in
         if anotherInstance == nil {
           anotherInstance = try! container.resolve() as AutoWiredClient
@@ -293,12 +293,12 @@ class AutoWiringTests: XCTestCase {
   func testThatItReusesInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithTheSameTag() {
     
     //given
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(.ObjectGraph) { ServiceImp2() }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(.Shared) { ServiceImp2() }
     
     var anotherInstance: AutoWiredClient?
     
-    container.register(tag: "tag", .ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+    container.register(tag: "tag", .Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
       .resolveDependencies { container, _ in
         if anotherInstance == nil {
           anotherInstance = try! container.resolve(tag: "tag") as AutoWiredClient
@@ -316,12 +316,12 @@ class AutoWiringTests: XCTestCase {
   func testThatItDoesNotReuseInstancesResolvedWithAutoWiringWhenUsingAutoWiringAgainWithNoTag() {
     
     //given
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(.ObjectGraph) { ServiceImp2() }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(.Shared) { ServiceImp2() }
     
     var anotherInstance: AutoWiredClient?
     
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+    container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
       .resolveDependencies { container, _ in
         if anotherInstance == nil {
           anotherInstance = try! container.resolve() as AutoWiredClient
@@ -338,10 +338,10 @@ class AutoWiringTests: XCTestCase {
   
   func testThatItUsesTagToResolveDependenciesWithAutoWiringWith1Argument() {
     //given
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(tag: "tag", .ObjectGraph) { ServiceImp2() as Service }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(tag: "tag", .Shared) { ServiceImp2() as Service }
     
-    container.register(.ObjectGraph) { (dep1: Service) -> ServiceImp3 in
+    container.register(.Shared) { (dep1: Service) -> ServiceImp3 in
       XCTAssertTrue(dep1 is ServiceImp2)
       return ServiceImp3()
     }
@@ -352,10 +352,10 @@ class AutoWiringTests: XCTestCase {
 
   func testThatItUsesTagToResolveDependenciesWithAutoWiringWith2Arguments() {
     //given
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(tag: "tag", .ObjectGraph) { ServiceImp2() as Service }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(tag: "tag", .Shared) { ServiceImp2() as Service }
     
-    container.register(.ObjectGraph) { (dep1: Service, dep2: Service) -> ServiceImp3 in
+    container.register(.Shared) { (dep1: Service, dep2: Service) -> ServiceImp3 in
       XCTAssertTrue(dep1 is ServiceImp2)
       XCTAssertTrue(dep2 is ServiceImp2)
       return ServiceImp3()
@@ -367,10 +367,10 @@ class AutoWiringTests: XCTestCase {
 
   func testThatItUsesTagToResolveDependenciesWithAutoWiringWith3Arguments() {
     //given
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(tag: "tag", .ObjectGraph) { ServiceImp2() as Service }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(tag: "tag", .Shared) { ServiceImp2() as Service }
     
-    container.register(.ObjectGraph) { (dep1: Service, dep2: Service, dep3: Service) -> ServiceImp3 in
+    container.register(.Shared) { (dep1: Service, dep2: Service, dep3: Service) -> ServiceImp3 in
       XCTAssertTrue(dep1 is ServiceImp2)
       XCTAssertTrue(dep2 is ServiceImp2)
       XCTAssertTrue(dep3 is ServiceImp2)
@@ -383,10 +383,10 @@ class AutoWiringTests: XCTestCase {
 
   func testThatItUsesTagToResolveDependenciesWithAutoWiringWith4Arguments() {
     //given
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(tag: "tag", .ObjectGraph) { ServiceImp2() as Service }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(tag: "tag", .Shared) { ServiceImp2() as Service }
     
-    container.register(.ObjectGraph) { (dep1: Service, dep2: Service, dep3: Service, dep4: Service) -> ServiceImp3 in
+    container.register(.Shared) { (dep1: Service, dep2: Service, dep3: Service, dep4: Service) -> ServiceImp3 in
       XCTAssertTrue(dep1 is ServiceImp2)
       XCTAssertTrue(dep2 is ServiceImp2)
       XCTAssertTrue(dep3 is ServiceImp2)
@@ -400,10 +400,10 @@ class AutoWiringTests: XCTestCase {
 
   func testThatItUsesTagToResolveDependenciesWithAutoWiringWith5Arguments() {
     //given
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(tag: "tag", .ObjectGraph) { ServiceImp2() as Service }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(tag: "tag", .Shared) { ServiceImp2() as Service }
     
-    container.register(.ObjectGraph) { (dep1: Service, dep2: Service, dep3: Service, dep4: Service, dep5: Service) -> ServiceImp3 in
+    container.register(.Shared) { (dep1: Service, dep2: Service, dep3: Service, dep4: Service, dep5: Service) -> ServiceImp3 in
       XCTAssertTrue(dep1 is ServiceImp2)
       XCTAssertTrue(dep2 is ServiceImp2)
       XCTAssertTrue(dep3 is ServiceImp2)
@@ -418,10 +418,10 @@ class AutoWiringTests: XCTestCase {
 
   func testThatItUsesTagToResolveDependenciesWithAutoWiringWith6Arguments() {
     //given
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(tag: "tag", .ObjectGraph) { ServiceImp2() as Service }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(tag: "tag", .Shared) { ServiceImp2() as Service }
     
-    container.register(.ObjectGraph) { (dep1: Service, dep2: Service, dep3: Service, dep4: Service, dep5: Service, dep6: Service) -> ServiceImp3 in
+    container.register(.Shared) { (dep1: Service, dep2: Service, dep3: Service, dep4: Service, dep5: Service, dep6: Service) -> ServiceImp3 in
       XCTAssertTrue(dep1 is ServiceImp2)
       XCTAssertTrue(dep2 is ServiceImp2)
       XCTAssertTrue(dep3 is ServiceImp2)
@@ -437,9 +437,9 @@ class AutoWiringTests: XCTestCase {
 
   func testThatItCanAutoWireOptional() {
     //given
-    container.register(.ObjectGraph) { ServiceImp1() as Service }
-    container.register(.ObjectGraph) { ServiceImp2() }
-    container.register(.ObjectGraph) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
+    container.register(.Shared) { ServiceImp1() as Service }
+    container.register(.Shared) { ServiceImp2() }
+    container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }
     
     var resolved: AutoWiredClient?
     //when

--- a/Tests/Dip/AutoWiringTests.swift
+++ b/Tests/Dip/AutoWiringTests.swift
@@ -224,7 +224,7 @@ class AutoWiringTests: XCTestCase {
         resolved.service2 = try container.resolve() as ServiceImp2
         
         //simulate that something goes wrong on the way
-        throw DipError.DefinitionNotFound(key: DefinitionKey(protocolType: ServiceImp1.self, argumentsType: Any.self))
+        throw DipError.DefinitionNotFound(key: DefinitionKey(type: ServiceImp1.self, typeOfArguments: Any.self))
     }
     
     container.register(.Shared) { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient }

--- a/Tests/Dip/ComponentScopeTests.swift
+++ b/Tests/Dip/ComponentScopeTests.swift
@@ -201,7 +201,7 @@ class ComponentScopeTests: XCTestCase {
     container.register(.Shared) { Client(server: try self.container.resolve()) as Client }
     
     container.register(.Shared) { Server() as Server }
-      .resolveDependencies { container, server in
+      .resolvingProperties { container, server in
         server.client = try container.resolve() as Client
     }
     
@@ -217,7 +217,7 @@ class ComponentScopeTests: XCTestCase {
     //given
     container.register(.Shared) { Client(server: try self.container.resolve()) as Client }
     container.register(.Shared) { Server() as Server }
-      .resolveDependencies { container, server in
+      .resolvingProperties { container, server in
         server.client = try container.resolve() as Client
     }
     
@@ -237,7 +237,7 @@ class ComponentScopeTests: XCTestCase {
     //given
     var service2: Service?
     container.register(.Shared) { ServiceImp1() as Service }
-      .resolveDependencies { (c, _) in
+      .resolvingProperties { (c, _) in
         //when service1 is resolved using this definition due to fallback to nil tag
         service2 = try c.resolve(tag: "service") as Service
         
@@ -257,7 +257,7 @@ class ComponentScopeTests: XCTestCase {
     //given
     var service2: Service?
     container.register(.Shared) { ServiceImp1() as Service }
-      .resolveDependencies { (c, service1) in
+      .resolvingProperties { (c, service1) in
         guard service2 == nil else { return }
         
         //when service1 is resolved using this definition due to fallback to nil tag
@@ -280,16 +280,16 @@ class ComponentScopeTests: XCTestCase {
     var eagerSingletonResolved = false
     
     container.register(tag: "eager", .EagerSingleton) { ServiceImp1() as Service }
-      .resolveDependencies { container, service in eagerSingletonResolved = true }
+      .resolvingProperties { container, service in eagerSingletonResolved = true }
     
     container.register(tag: "singleton", .Singleton) { ServiceImp1() as Service }
-      .resolveDependencies { container, service in XCTFail() }
+      .resolvingProperties { container, service in XCTFail() }
 
     container.register(tag: "prototype", .Unique) { ServiceImp1() as Service }
-      .resolveDependencies { container, service in XCTFail() }
+      .resolvingProperties { container, service in XCTFail() }
 
     container.register(tag: "graph", .Shared) { ServiceImp1() as Service }
-      .resolveDependencies { container, service in XCTFail() }
+      .resolvingProperties { container, service in XCTFail() }
     
     //when
     try! container.bootstrap()
@@ -311,7 +311,7 @@ class ComponentScopeTests: XCTestCase {
     var anyImpOtherService: Any!
     
     container.register(.Shared) { ServiceImp1() as Service }
-      .resolveDependencies { container, service in
+      .resolvingProperties { container, service in
         otherService = try! container.resolve() as Service?
         impOtherService = try! container.resolve() as Service!
         anyOtherService = try! container.resolve((Service?).self)

--- a/Tests/Dip/ContextTests.swift
+++ b/Tests/Dip/ContextTests.swift
@@ -67,7 +67,7 @@ class ContextTests: XCTestCase {
       XCTAssertTrue(self.container.context.resolvingType == Service.self)
       let _ = try self.container.resolve() as ServiceImp1
       return ServiceImp1() as Service
-      }.resolveDependencies { _ in
+      }.resolvingProperties { _ in
         XCTAssertTrue(self.container.context.resolvingType == Service.self)
         let _ = try self.container.resolve() as ServiceImp1
     }
@@ -75,7 +75,7 @@ class ContextTests: XCTestCase {
     container.register { () -> ServiceImp1 in
       XCTAssertTrue(self.container.context.resolvingType == ServiceImp1.self)
       return ServiceImp1()
-      }.resolveDependencies { _ in
+      }.resolvingProperties { _ in
         XCTAssertTrue(self.container.context.resolvingType == ServiceImp1.self)
     }
     
@@ -87,7 +87,7 @@ class ContextTests: XCTestCase {
       XCTAssertNil(self.container.context.injectedInType)
       let _ = try self.container.resolve() as ServiceImp1
       return ServiceImp1() as Service
-      }.resolveDependencies { _ in
+      }.resolvingProperties { _ in
         XCTAssertNil(self.container.context.injectedInType)
         let _ = try self.container.resolve() as ServiceImp1
     }
@@ -95,7 +95,7 @@ class ContextTests: XCTestCase {
     container.register { () -> ServiceImp1 in
       XCTAssertTrue(self.container.context.injectedInType == Service.self)
       return ServiceImp1()
-      }.resolveDependencies { _ in
+      }.resolvingProperties { _ in
         XCTAssertTrue(self.container.context.injectedInType == Service.self)
     }
     
@@ -108,7 +108,7 @@ class ContextTests: XCTestCase {
       XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
       let _ = try self.container.resolve(tag: "otherTag") as ServiceImp1
       return ServiceImp1() as Service
-      }.resolveDependencies { _ in
+      }.resolvingProperties { _ in
         XCTAssertNotNil(self.container.context.tag)
         XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
         let _ = try self.container.resolve(tag: "otherTag") as ServiceImp1
@@ -118,7 +118,7 @@ class ContextTests: XCTestCase {
       XCTAssertNotNil(self.container.context.tag)
       XCTAssertTrue(DependencyContainer.Tag.String("otherTag") ~= self.container.context.tag!)
       return ServiceImp1()
-      }.resolveDependencies { _ in
+      }.resolvingProperties { _ in
         XCTAssertNotNil(self.container.context.tag)
         XCTAssertTrue(DependencyContainer.Tag.String("otherTag") ~= self.container.context.tag!)
     }
@@ -139,7 +139,7 @@ class ContextTests: XCTestCase {
         XCTAssertTrue(DependencyContainer.Tag.String("injectedTag") ~= self.container.context.tag!)
       }
       return ServiceImp2()
-      }.resolveDependencies { _ in
+      }.resolvingProperties { _ in
         if self.container.context.injectedInProperty == "injectedNilTag" {
           XCTAssertNil(self.container.context.tag)
         }
@@ -153,7 +153,7 @@ class ContextTests: XCTestCase {
       XCTAssertNotNil(self.container.context.tag)
       XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
       return ServiceImp2()
-      }.resolveDependencies { _ in
+      }.resolvingProperties { _ in
         XCTAssertNotNil(self.container.context.tag)
         XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
     }
@@ -164,14 +164,14 @@ class ContextTests: XCTestCase {
   func testThatContextStoresTheTagPassedToResolveWhenAutoWiring() {
     container.register { (_: ServiceImp1) -> Service in
       return ServiceImp1() as Service
-      }.resolveDependencies { _ in
+      }.resolvingProperties { _ in
     }
     
     container.register { () -> ServiceImp1 in
       XCTAssertNotNil(self.container.context.tag)
       XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
       return ServiceImp1()
-      }.resolveDependencies { _ in
+      }.resolvingProperties { _ in
         XCTAssertNotNil(self.container.context.tag)
         XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
     }
@@ -185,7 +185,7 @@ class ContextTests: XCTestCase {
       XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
       let _ = try self.container.resolve() as ServiceImp1
       return ServiceImp1() as Service
-      }.resolveDependencies { _ in
+      }.resolvingProperties { _ in
         XCTAssertNotNil(self.container.context.tag)
         XCTAssertTrue(DependencyContainer.Tag.String("tag") ~= self.container.context.tag!)
         let _ = try self.container.resolve() as ServiceImp1
@@ -194,7 +194,7 @@ class ContextTests: XCTestCase {
     container.register { () -> ServiceImp1 in
       XCTAssertNil(self.container.context.tag)
       return ServiceImp1()
-      }.resolveDependencies { _ in
+      }.resolvingProperties { _ in
         XCTAssertNil(self.container.context.tag)
     }
     
@@ -211,7 +211,7 @@ class ContextTests: XCTestCase {
       XCTAssertNotNil(self.container.context.injectedInProperty)
       XCTAssertTrue(names.contains(self.container.context.injectedInProperty!))
       return ServiceImp2()
-      }.resolveDependencies { _ in
+      }.resolvingProperties { _ in
         XCTAssertNotNil(self.container.context.injectedInProperty)
         XCTAssertTrue(names.contains(self.container.context.injectedInProperty!))
     }

--- a/Tests/Dip/DefinitionTests.swift
+++ b/Tests/Dip/DefinitionTests.swift
@@ -87,12 +87,12 @@ class DefinitionTests: XCTestCase {
     
     //given
     let def = DefinitionOf<Service, () -> Service>(scope: .Unique) { ServiceImp() as Service }
-      .resolveDependencies { container, service in
+      .resolvingProperties { container, service in
         blockCalled = true
     }
     
     //when
-    try! def.resolveDependenciesOf(ServiceImp(), withContainer: DependencyContainer())
+    try! def.resolveProperties(instance: ServiceImp(), container: DependencyContainer())
     
     //then
     XCTAssertTrue(blockCalled)
@@ -103,12 +103,12 @@ class DefinitionTests: XCTestCase {
     
     //given
     let def = DefinitionOf<Service, () -> Service>(scope: .Unique) { ServiceImp() as Service }
-      .resolveDependencies { container, service in
+      .resolvingProperties { container, service in
         blockCalled = true
     }
     
     //when
-    try! def.resolveDependenciesOf(String(), withContainer: DependencyContainer())
+    try! def.resolveProperties(instance: String(), container: DependencyContainer())
     
     //then
     XCTAssertFalse(blockCalled)

--- a/Tests/Dip/DefinitionTests.swift
+++ b/Tests/Dip/DefinitionTests.swift
@@ -86,7 +86,7 @@ class DefinitionTests: XCTestCase {
     var blockCalled = false
     
     //given
-    let def = DefinitionOf<Service, () -> Service>(scope: .Prototype) { ServiceImp() as Service }
+    let def = DefinitionOf<Service, () -> Service>(scope: .Unique) { ServiceImp() as Service }
       .resolveDependencies { container, service in
         blockCalled = true
     }
@@ -102,7 +102,7 @@ class DefinitionTests: XCTestCase {
     var blockCalled = false
     
     //given
-    let def = DefinitionOf<Service, () -> Service>(scope: .Prototype) { ServiceImp() as Service }
+    let def = DefinitionOf<Service, () -> Service>(scope: .Unique) { ServiceImp() as Service }
       .resolveDependencies { container, service in
         blockCalled = true
     }
@@ -115,7 +115,7 @@ class DefinitionTests: XCTestCase {
   }
   
   func testThatItRegisteresOptionalTypesAsForwardedTypes() {
-    let def = DefinitionOf<Service, () -> Service>(scope: .Prototype) { ServiceImp() as Service }
+    let def = DefinitionOf<Service, () -> Service>(scope: .Unique) { ServiceImp() as Service }
     
     XCTAssertTrue(def.implementingTypes.contains({ $0 == Service?.self }))
     XCTAssertTrue(def.implementingTypes.contains({ $0 == Service!.self }))

--- a/Tests/Dip/DefinitionTests.swift
+++ b/Tests/Dip/DefinitionTests.swift
@@ -51,32 +51,32 @@ class DefinitionTests: XCTestCase {
   #endif
 
   func testThatDefinitionKeyIsEqualBy_Type_Factory_Tag() {
-    let equalKey1 = DefinitionKey(protocolType: Service.self, argumentsType: F1.self, associatedTag: tag1)
-    let equalKey2 = DefinitionKey(protocolType: Service.self, argumentsType: F1.self, associatedTag: tag1)
+    let equalKey1 = DefinitionKey(type: Service.self, typeOfArguments: F1.self, tag: tag1)
+    let equalKey2 = DefinitionKey(type: Service.self, typeOfArguments: F1.self, tag: tag1)
     
     XCTAssertEqual(equalKey1, equalKey2)
     XCTAssertEqual(equalKey1.hashValue, equalKey2.hashValue)
   }
   
   func testThatDefinitionKeysWithDifferentTypesAreNotEqual() {
-    let keyWithDifferentType1 = DefinitionKey(protocolType: Service.self, argumentsType: F1.self, associatedTag: nil)
-    let keyWithDifferentType2 = DefinitionKey(protocolType: AnyObject.self, argumentsType: F1.self, associatedTag: nil)
+    let keyWithDifferentType1 = DefinitionKey(type: Service.self, typeOfArguments: F1.self, tag: nil)
+    let keyWithDifferentType2 = DefinitionKey(type: AnyObject.self, typeOfArguments: F1.self, tag: nil)
     
     XCTAssertNotEqual(keyWithDifferentType1, keyWithDifferentType2)
     XCTAssertNotEqual(keyWithDifferentType1.hashValue, keyWithDifferentType2.hashValue)
   }
   
   func testThatDefinitionKeysWithDifferentFactoriesAreNotEqual() {
-    let keyWithDifferentFactory1 = DefinitionKey(protocolType: Service.self, argumentsType: F1.self, associatedTag: nil)
-    let keyWithDifferentFactory2 = DefinitionKey(protocolType: Service.self, argumentsType: F2.self, associatedTag: nil)
+    let keyWithDifferentFactory1 = DefinitionKey(type: Service.self, typeOfArguments: F1.self, tag: nil)
+    let keyWithDifferentFactory2 = DefinitionKey(type: Service.self, typeOfArguments: F2.self, tag: nil)
     
     XCTAssertNotEqual(keyWithDifferentFactory1, keyWithDifferentFactory2)
     XCTAssertNotEqual(keyWithDifferentFactory1.hashValue, keyWithDifferentFactory2.hashValue)
   }
   
   func testThatDefinitionKeysWithDifferentTagsAreNotEqual() {
-    let keyWithDifferentTag1 = DefinitionKey(protocolType: Service.self, argumentsType: F1.self, associatedTag: tag1)
-    let keyWithDifferentTag2 = DefinitionKey(protocolType: Service.self, argumentsType: F1.self, associatedTag: tag2)
+    let keyWithDifferentTag1 = DefinitionKey(type: Service.self, typeOfArguments: F1.self, tag: tag1)
+    let keyWithDifferentTag2 = DefinitionKey(type: Service.self, typeOfArguments: F1.self, tag: tag2)
     
     XCTAssertNotEqual(keyWithDifferentTag1, keyWithDifferentTag2)
     XCTAssertNotEqual(keyWithDifferentTag1.hashValue, keyWithDifferentTag2.hashValue)

--- a/Tests/Dip/DipTests.swift
+++ b/Tests/Dip/DipTests.swift
@@ -310,7 +310,7 @@ class DipTests: XCTestCase {
     container.register { ServiceImp1() as Service }
     
     //when
-    AssertThrows(expression: try container.resolve(withArguments: "some string") as Service) { error in
+    AssertThrows(expression: try container.resolve(arguments: "some string") as Service) { error in
       guard case let DipError.DefinitionNotFound(key) = error else { return false }
       
       //then
@@ -321,7 +321,7 @@ class DipTests: XCTestCase {
     }
 
     //and when
-    AssertThrows(expression: try container.resolve(Service.self, withArguments: "some string")) { error in
+    AssertThrows(expression: try container.resolve(Service.self, arguments: "some string")) { error in
       guard case let DipError.DefinitionNotFound(key) = error else { return false }
       
       //then

--- a/Tests/Dip/DipTests.swift
+++ b/Tests/Dip/DipTests.swift
@@ -90,7 +90,7 @@ class DipTests: XCTestCase {
         //referencing container in factory
         let _ = container
         return ServiceImp1() as Service
-        }.resolveDependencies() { container, _ in
+        }.resolvingProperties { container, _ in
           //when container is passed as argument there will be no retain cycle
           let _ = container
       }
@@ -217,7 +217,7 @@ class DipTests: XCTestCase {
   func testThatItCallsResolveDependenciesOnDefinition() {
     //given
     var resolveDependenciesCalled = false
-    container.register { ServiceImp1() as Service }.resolveDependencies { (c, s) in
+    container.register { ServiceImp1() as Service }.resolvingProperties { (c, s) in
       resolveDependenciesCalled = true
     }
     
@@ -360,7 +360,7 @@ class DipTests: XCTestCase {
     let failedKey = DefinitionKey(type: Any.self, typeOfArguments: Any.self)
     let expectedError = DipError.DefinitionNotFound(key: failedKey)
     container.register { ServiceImp1() as Service }
-      .resolveDependencies { container, service in
+      .resolvingProperties { container, service in
         //simulate throwing error when resolving dependency
         throw expectedError
     }
@@ -385,19 +385,19 @@ class DipTests: XCTestCase {
   func testThatItCallsDidResolveDependenciesOnResolvableIntance() {
     //given
     container.register { ResolvableService() as Service }
-      .resolveDependencies { _, service in
+      .resolvingProperties { _, service in
         XCTAssertFalse((service as! ResolvableService).didResolveDependenciesCalled, "didResolveDependencies should not be called yet")
         return
     }
 
     container.register(tag: "graph", .Shared) { ResolvableService() as Service }
-      .resolveDependencies { _, service in
+      .resolvingProperties { _, service in
         XCTAssertFalse((service as! ResolvableService).didResolveDependenciesCalled, "didResolveDependencies should not be called yet")
         return
     }
 
     container.register(tag: "singleton", .Singleton) { ResolvableService() as Service }
-      .resolveDependencies { _, service in
+      .resolvingProperties { _, service in
         XCTAssertFalse((service as! ResolvableService).didResolveDependenciesCalled, "didResolveDependencies should not be called yet")
         return
     }
@@ -436,7 +436,7 @@ class DipTests: XCTestCase {
     var resolveDependenciesCalled = false
     var service2: Service!
     container.register { ResolvableService() as Service }
-      .resolveDependencies { _, service in
+      .resolvingProperties { _, service in
         if !resolveDependenciesCalled {
           resolveDependenciesCalled = true
           service2 = try self.container.resolve() as Service
@@ -499,13 +499,13 @@ class DipTests: XCTestCase {
 
     //given
     container.register(.Shared) { try ResolvableServer(client: self.container.resolve()) as Server }
-      .resolveDependencies { (container: DependencyContainer, server: Server) in
+      .resolvingProperties { (container: DependencyContainer, server: Server) in
         let server = server as! ResolvableServer
         server.secondClient = try container.resolve() as Client
     }
     
     container.register(.Shared) { ResolvableClient() as Client }
-      .resolveDependencies { (container: DependencyContainer, client: Client) in
+      .resolvingProperties { (container: DependencyContainer, client: Client) in
         let client = client as! ResolvableClient
         client.server = try container.resolve() as Server
         client.secondServer = try container.resolve() as Server
@@ -537,7 +537,7 @@ class DipTests: XCTestCase {
     var createdService = false
     
     let service = container.register { ServiceImp1() }
-      .resolveDependencies { container, _ in
+      .resolvingProperties { container, _ in
         if container.context.resolvingType == ServiceImp1.self {
           createdService1 = true
         }
@@ -548,12 +548,12 @@ class DipTests: XCTestCase {
     container.register(service, type: Service.self)
     
     container.register(tag: "tag") { ServiceImp2() as Service }
-      .resolveDependencies { _ in
+      .resolvingProperties { _ in
         createdService2 = true
     }
     
     container.register() { (arg: String) in ServiceImp1() }
-      .resolveDependencies { _ in
+      .resolvingProperties { _ in
         createdService3 = true
     }
     
@@ -677,7 +677,7 @@ extension DipTests {
 
     let clientContainer = DependencyContainer()
     clientContainer.register(.Shared) { ClientImp() as Client }
-      .resolveDependencies { container, client in
+      .resolvingProperties { container, client in
         let client = client as! ClientImp
         client.server = try container.resolve() as Server
         client.anotherServer = try container.resolve() as Server

--- a/Tests/Dip/DipTests.swift
+++ b/Tests/Dip/DipTests.swift
@@ -390,7 +390,7 @@ class DipTests: XCTestCase {
         return
     }
 
-    container.register(tag: "graph", .ObjectGraph) { ResolvableService() as Service }
+    container.register(tag: "graph", .Shared) { ResolvableService() as Service }
       .resolveDependencies { _, service in
         XCTAssertFalse((service as! ResolvableService).didResolveDependenciesCalled, "didResolveDependencies should not be called yet")
         return
@@ -498,13 +498,13 @@ class DipTests: XCTestCase {
     }
 
     //given
-    container.register(.ObjectGraph) { try ResolvableServer(client: self.container.resolve()) as Server }
+    container.register(.Shared) { try ResolvableServer(client: self.container.resolve()) as Server }
       .resolveDependencies { (container: DependencyContainer, server: Server) in
         let server = server as! ResolvableServer
         server.secondClient = try container.resolve() as Client
     }
     
-    container.register(.ObjectGraph) { ResolvableClient() as Client }
+    container.register(.Shared) { ResolvableClient() as Client }
       .resolveDependencies { (container: DependencyContainer, client: Client) in
         let client = client as! ResolvableClient
         client.server = try container.resolve() as Server
@@ -673,10 +673,10 @@ extension DipTests {
     }
     
     let serverContainer = DependencyContainer()
-    serverContainer.register(.ObjectGraph) { ServerImp(client: $0) as Server }
+    serverContainer.register(.Shared) { ServerImp(client: $0) as Server }
 
     let clientContainer = DependencyContainer()
-    clientContainer.register(.ObjectGraph) { ClientImp() as Client }
+    clientContainer.register(.Shared) { ClientImp() as Client }
       .resolveDependencies { container, client in
         let client = client as! ClientImp
         client.server = try container.resolve() as Server

--- a/Tests/Dip/DipTests.swift
+++ b/Tests/Dip/DipTests.swift
@@ -260,7 +260,7 @@ class DipTests: XCTestCase {
       guard case let DipError.DefinitionNotFound(key) = error else { return false }
       
       //then
-      let expectedKey = DefinitionKey(protocolType: Service.self, argumentsType: Void.self, associatedTag: nil)
+      let expectedKey = DefinitionKey(type: Service.self, typeOfArguments: Void.self, tag: nil)
       XCTAssertEqual(key, expectedKey)
 
       return true
@@ -271,7 +271,7 @@ class DipTests: XCTestCase {
       guard case let DipError.DefinitionNotFound(key) = error else { return false }
       
       //then
-      let expectedKey = DefinitionKey(protocolType: Service.self, argumentsType: Void.self, associatedTag: nil)
+      let expectedKey = DefinitionKey(type: Service.self, typeOfArguments: Void.self, tag: nil)
       XCTAssertEqual(key, expectedKey)
       
       return true
@@ -287,7 +287,7 @@ class DipTests: XCTestCase {
       guard case let DipError.DefinitionNotFound(key) = error else { return false }
       
       //then
-      let expectedKey = DefinitionKey(protocolType: Service.self, argumentsType: Void.self, associatedTag: "other tag")
+      let expectedKey = DefinitionKey(type: Service.self, typeOfArguments: Void.self, tag: "other tag")
       XCTAssertEqual(key, expectedKey)
       
       return true
@@ -298,7 +298,7 @@ class DipTests: XCTestCase {
       guard case let DipError.DefinitionNotFound(key) = error else { return false }
       
       //then
-      let expectedKey = DefinitionKey(protocolType: Service.self, argumentsType: Void.self, associatedTag: "other tag")
+      let expectedKey = DefinitionKey(type: Service.self, typeOfArguments: Void.self, tag: "other tag")
       XCTAssertEqual(key, expectedKey)
       
       return true
@@ -314,7 +314,7 @@ class DipTests: XCTestCase {
       guard case let DipError.DefinitionNotFound(key) = error else { return false }
       
       //then
-      let expectedKey = DefinitionKey(protocolType: Service.self, argumentsType: String.self, associatedTag: nil)
+      let expectedKey = DefinitionKey(type: Service.self, typeOfArguments: String.self, tag: nil)
       XCTAssertEqual(key, expectedKey)
 
       return true
@@ -325,7 +325,7 @@ class DipTests: XCTestCase {
       guard case let DipError.DefinitionNotFound(key) = error else { return false }
       
       //then
-      let expectedKey = DefinitionKey(protocolType: Service.self, argumentsType: String.self, associatedTag: nil)
+      let expectedKey = DefinitionKey(type: Service.self, typeOfArguments: String.self, tag: nil)
       XCTAssertEqual(key, expectedKey)
       
       return true
@@ -334,7 +334,7 @@ class DipTests: XCTestCase {
   
   func testThatItThrowsErrorIfConstructorThrows() {
     //given
-    let failedKey = DefinitionKey(protocolType: Any.self, argumentsType: Any.self)
+    let failedKey = DefinitionKey(type: Any.self, typeOfArguments: Any.self)
     let expectedError = DipError.DefinitionNotFound(key: failedKey)
     container.register { () throws -> Service in throw expectedError }
     
@@ -357,7 +357,7 @@ class DipTests: XCTestCase {
   
   func testThatItThrowsErrorIfFailsToResolveDependency() {
     //given
-    let failedKey = DefinitionKey(protocolType: Any.self, argumentsType: Any.self)
+    let failedKey = DefinitionKey(type: Any.self, typeOfArguments: Any.self)
     let expectedError = DipError.DefinitionNotFound(key: failedKey)
     container.register { ServiceImp1() as Service }
       .resolveDependencies { container, service in
@@ -611,7 +611,7 @@ class DipTests: XCTestCase {
     AssertNoThrow(expression: try container.validate())
     
     //given
-    let key = DefinitionKey(protocolType: Service.self, argumentsType: Void.self, associatedTag: nil)
+    let key = DefinitionKey(type: Service.self, typeOfArguments: Void.self, tag: nil)
     container.register { () -> Service in
       throw DipError.DefinitionNotFound(key: key)
     }

--- a/Tests/Dip/RuntimeArgumentsTests.swift
+++ b/Tests/Dip/RuntimeArgumentsTests.swift
@@ -86,13 +86,13 @@ class RuntimeArgumentsTests: XCTestCase {
     })
     
     //when
-    let service = try! container.resolve(withArguments: arg1) as Service
+    let service = try! container.resolve(arguments: arg1) as Service
     
     //then
     XCTAssertTrue(service is ServiceImp1)
     
     //when
-    let anyService = try! container.resolve(Service.self, withArguments: arg1)
+    let anyService = try! container.resolve(Service.self, arguments: arg1)
     
     //then
     XCTAssertTrue(anyService is ServiceImp1)
@@ -108,13 +108,13 @@ class RuntimeArgumentsTests: XCTestCase {
     }
     
     //when
-    let service = try! container.resolve(withArguments: arg1, arg2) as Service
+    let service = try! container.resolve(arguments: arg1, arg2) as Service
     
     //then
     XCTAssertTrue(service is ServiceImp1)
 
     //when
-    let anyService = try! container.resolve(Service.self, withArguments: arg1, arg2)
+    let anyService = try! container.resolve(Service.self, arguments: arg1, arg2)
     
     //then
     XCTAssertTrue(anyService is ServiceImp1)
@@ -130,13 +130,13 @@ class RuntimeArgumentsTests: XCTestCase {
     }
     
     //when
-    let service = try! container.resolve(withArguments: arg1, arg2, arg3) as Service
+    let service = try! container.resolve(arguments: arg1, arg2, arg3) as Service
     
     //then
     XCTAssertTrue(service is ServiceImp1)
     
     //when
-    let anyService = try! container.resolve(Service.self, withArguments: arg1, arg2, arg3)
+    let anyService = try! container.resolve(Service.self, arguments: arg1, arg2, arg3)
     
     //then
     XCTAssertTrue(anyService is ServiceImp1)
@@ -153,13 +153,13 @@ class RuntimeArgumentsTests: XCTestCase {
     }
     
     //when
-    let service = try! container.resolve(withArguments: arg1, arg2, arg3, arg4) as Service
+    let service = try! container.resolve(arguments: arg1, arg2, arg3, arg4) as Service
     
     //then
     XCTAssertTrue(service is ServiceImp1)
     
     //when
-    let anyService = try! container.resolve(Service.self, withArguments: arg1, arg2, arg3, arg4)
+    let anyService = try! container.resolve(Service.self, arguments: arg1, arg2, arg3, arg4)
     
     //then
     XCTAssertTrue(anyService is ServiceImp1)
@@ -177,13 +177,13 @@ class RuntimeArgumentsTests: XCTestCase {
     }
     
     //when
-    let service = try! container.resolve(withArguments: arg1, arg2, arg3, arg4, arg5) as Service
+    let service = try! container.resolve(arguments: arg1, arg2, arg3, arg4, arg5) as Service
     
     //then
     XCTAssertTrue(service is ServiceImp1)
     
     //when
-    let anyService = try! container.resolve(Service.self, withArguments: arg1, arg2, arg3, arg4, arg5)
+    let anyService = try! container.resolve(Service.self, arguments: arg1, arg2, arg3, arg4, arg5)
     
     //then
     XCTAssertTrue(anyService is ServiceImp1)
@@ -202,13 +202,13 @@ class RuntimeArgumentsTests: XCTestCase {
     }
     
     //when
-    let service = try! container.resolve(withArguments: arg1, arg2, arg3, arg4, arg5, arg6) as Service
+    let service = try! container.resolve(arguments: arg1, arg2, arg3, arg4, arg5, arg6) as Service
     
     //then
     XCTAssertTrue(service is ServiceImp1)
     
     //when
-    let anyService = try! container.resolve(Service.self, withArguments: arg1, arg2, arg3, arg4, arg5, arg6)
+    let anyService = try! container.resolve(Service.self, arguments: arg1, arg2, arg3, arg4, arg5, arg6)
     
     //then
     XCTAssertTrue(anyService is ServiceImp1)
@@ -221,8 +221,8 @@ class RuntimeArgumentsTests: XCTestCase {
     container.register { (a1: Int, a2: Int) in ServiceImp2() as Service }
     
     //when
-    let service1 = try! container.resolve(withArguments: arg1) as Service
-    let service2 = try! container.resolve(withArguments: arg1, arg2) as Service
+    let service1 = try! container.resolve(arguments: arg1) as Service
+    let service2 = try! container.resolve(arguments: arg1, arg2) as Service
     
     //then
     XCTAssertTrue(service1 is ServiceImp1)
@@ -236,8 +236,8 @@ class RuntimeArgumentsTests: XCTestCase {
     container.register(factory: { (a1: String) in ServiceImp2() as Service })
     
     //when
-    let service1 = try! container.resolve(withArguments: arg1) as Service
-    let service2 = try! container.resolve(withArguments: arg2) as Service
+    let service1 = try! container.resolve(arguments: arg1) as Service
+    let service2 = try! container.resolve(arguments: arg2) as Service
     
     //then
     XCTAssertTrue(service1 is ServiceImp1)
@@ -251,8 +251,8 @@ class RuntimeArgumentsTests: XCTestCase {
     container.register { (a1: String, a2: Int) in ServiceImp2() as Service }
     
     //when
-    let service1 = try! container.resolve(withArguments: arg1, arg2) as Service
-    let service2 = try! container.resolve(withArguments: arg2, arg1) as Service
+    let service1 = try! container.resolve(arguments: arg1, arg2) as Service
+    let service2 = try! container.resolve(arguments: arg2, arg1) as Service
     
     //then
     XCTAssertTrue(service1 is ServiceImp1)
@@ -263,11 +263,11 @@ class RuntimeArgumentsTests: XCTestCase {
     //given
     let arg1 = 1, arg2 = 2
     container.register { (a1: Int, a2: Int) in ServiceImp1() as Service }
-    let service1 = try! container.resolve(withArguments: arg1, arg2) as Service
+    let service1 = try! container.resolve(arguments: arg1, arg2) as Service
     
     //when
     container.register { (a1: Int, a2: Int) in ServiceImp2() as Service }
-    let service2 = try! container.resolve(withArguments: arg1, arg2) as Service
+    let service2 = try! container.resolve(arguments: arg1, arg2) as Service
     
     //then
     XCTAssertTrue(service1 is ServiceImp1)
@@ -282,9 +282,9 @@ class RuntimeArgumentsTests: XCTestCase {
     container.register { (port: Int, url: String!) in ServiceImp(name: name3, baseURL: url, port: port) as Service }
     
     //when
-    let service1 = try! container.resolve(withArguments: 80, "http://example.com") as Service
-    let service2 = try! container.resolve(withArguments: 80, "http://example.com" as String?) as Service
-    let service3 = try! container.resolve(withArguments: 80, "http://example.com" as String!) as Service
+    let service1 = try! container.resolve(arguments: 80, "http://example.com") as Service
+    let service2 = try! container.resolve(arguments: 80, "http://example.com" as String?) as Service
+    let service3 = try! container.resolve(arguments: 80, "http://example.com" as String!) as Service
     
     //then
     XCTAssertEqual(service1.name, name1)

--- a/Tests/Dip/ThreadSafetyTests.swift
+++ b/Tests/Dip/ThreadSafetyTests.swift
@@ -191,7 +191,7 @@ class ThreadSafetyTests: XCTestCase {
     }
     
     container.register(.Shared) { ServerImp() as Server }
-      .resolveDependencies { container, server in
+      .resolvingProperties { container, server in
         server.client = resolveClientSync()
     }
     

--- a/Tests/Dip/ThreadSafetyTests.swift
+++ b/Tests/Dip/ThreadSafetyTests.swift
@@ -186,11 +186,11 @@ class ThreadSafetyTests: XCTestCase {
   
   
   func testCircularReferenceThreadSafety() {
-    container.register(.ObjectGraph) {
+    container.register(.Shared) {
       ClientImp(server: try container.resolve()) as Client
     }
     
-    container.register(.ObjectGraph) { ServerImp() as Server }
+    container.register(.Shared) { ServerImp() as Server }
       .resolveDependencies { container, server in
         server.client = resolveClientSync()
     }


### PR DESCRIPTION
With Swift3 API guidelines in mind here is what I propose to rename in public API:

1. `ObjectGraph` -> `Shared`, `Prototype` -> `Unique`. These names will make it more clear how these scopes affect instances
2. `resolveDependencies` -> `resolvingProperties`
3. `DefinitionKey` properties: `protocolType` -> `type`, `associatedTag` -> `tag`, `argumentsType` -> `typeOfArguments`. Additional words in original names do not add any value to understanding meaning of these properties.
4.  `resolve` method parameter `withArguments` -> `arguments`
5. switch places for `scope` and `tag` parameters in `register` method. This does not break API in Swift2 but with Swift 3 will require to follow the order from declaration (SE-0060). `register(.Shared, tag: "some")` looks nicer than `register(tag: "some", scope: .Shared)`

There are also some internal methods renaming, but obviously its not that critical.