### PR TITLE
Improved type forwarding

### DIFF
--- a/Sources/AutoWiring.swift
+++ b/Sources/AutoWiring.swift
@@ -122,21 +122,24 @@ private func ~=(lhs: KeyDefinitionPair, rhs: KeyDefinitionPair) -> Bool {
   return true
 }
 
-func filter(definitions: [KeyDefinitionPair], byKey key: DefinitionKey) -> [KeyDefinitionPair] {
-  return definitions
+/// Returns key-defintion pairs with definitions able to resolve that type (directly or via type forwarding) 
+/// and which tag matches provided key's tag or is nil.
+/// Additionally matches defintions by type of runtime arguments.
+func filter(definitions: [KeyDefinitionPair], byKey key: DefinitionKey, byTypeOfArguments: Bool = false) -> [KeyDefinitionPair] {
+  let definitions = definitions
     .filter({ $0.key.type == key.type || $0.definition.doesImplements(key.type) })
     .filter({ $0.key.tag == key.tag || $0.key.tag == nil })
+  if byTypeOfArguments {
+    return definitions.filter({ $0.key.typeOfArguments == key.typeOfArguments })
+  }
+  else {
+    return definitions
+  }
 }
 
-func filter(definitions: [KeyDefinitionPair], byKeyAndTypeOfArguments key: DefinitionKey) -> [KeyDefinitionPair] {
-  return filter(definitions, byKey: key)
-    .filter({ $0.key.typeOfArguments == key.typeOfArguments })
-}
-
+/// Orders key-definition pairs putting first definitions registered for the same tag.
 func order(definitions: [KeyDefinitionPair], byTag tag: DependencyContainer.Tag?) -> [KeyDefinitionPair] {
   return
-    //first will try to use tagged definitions
     definitions.filter({ $0.key.tag == tag }) +
-    //then will use not tagged definitions
     definitions.filter({ $0.key.tag != tag })
 }

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -327,6 +327,9 @@ extension DependencyContainer {
     
     threadSafe {
       let key = DefinitionKey(type: T.self, typeOfArguments: U.self, tag: tag?.dependencyTag)
+      if let _ = definitions[key] {
+        remove(definitionForKey: key)
+      }
       
       definition.container = self
       definitions[key] = definition
@@ -491,10 +494,15 @@ extension DependencyContainer {
   }
   
   private func previouslyResolved<T>(definition: _Definition, key: DefinitionKey) -> T? {
+    //first check if exact key was already resolved
+    if let previouslyResolved = resolvedInstances[key: key, inScope: definition.scope] as? T {
+      return previouslyResolved
+    }
+    //then check if any related type was already resolved
     let keys = definition.implementingTypes.map({
       DefinitionKey(type: $0, typeOfArguments: key.typeOfArguments, tag: key.tag)
     })
-    for key in [key] + keys {
+    for key in keys {
       if let previouslyResolved = resolvedInstances[key: key, inScope: definition.scope] as? T {
         return previouslyResolved
       }
@@ -504,15 +512,15 @@ extension DependencyContainer {
   
   /// Searches for definition that matches provided key
   private func definition(matching key: DefinitionKey) -> KeyDefinitionPair? {
-    let typeDefinitions = definitions.filter({ $0.0.type ==  key.type })
-    guard !typeDefinitions.isEmpty else {
-      return typeForwardingDefinition(key)
-    }
-    
     if let definition = (self.definitions[key] ?? self.definitions[key.tagged(nil)]) {
       return (key, definition)
     }
-
+    
+    //if no definition registered for exact type try to find type-forwarding definition that can resolve the type
+    //that will actually happen only when resolving optionals
+    if definitions.filter({ $0.0.type == key.type }).isEmpty {
+      return typeForwardingDefinition(key)
+    }
     return nil
   }
   


### PR DESCRIPTION
- removed deprecation annotation for register(_:type:tag:)
- added removing previously registered definition when overriding (for proper cleanup)
- fixed calling resolvingProperties set after registering type-forwarding
- improved tests and code comments