### PR TITLE
Optional type parameter in register methods

### DIFF
--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -250,24 +250,44 @@ extension DependencyContainer {
    Register factory for type `T` and associate it with an optional tag.
 
    - parameters:
-      - tag: The arbitrary tag to associate this factory with. Pass `nil` to associate with any tag. Default value is `nil`.
       - scope: The scope to use for instance created by the factory. Default value is `Shared`.
-      - factory: The factory to register.
+      - type: Type to register definition for. Default value is return value of factory.
+      - tag: The arbitrary tag to associate this factory with. Pass `nil` to associate with any tag. Default value is `nil`.
+      - factory: The factory that produces instance of `type`. Will be used to resolve instances of `type`.
 
    - returns: A registered definition.
 
    - note: You should cast the factory return type to the protocol you want to register it for
-           (unless you want to register concrete type).
+           (unless you want to register concrete type) or provide `type` parameter.
+   
+   - seealso: `Definition`, `ComponentScope`, `DependencyTagConvertible`
 
    **Example**:
    ```swift
+   //Register ServiceImp as Service
    container.register { ServiceImp() as Service }
+   
+   //Register ServiceImp as Service named by "service"
    container.register(tag: "service") { ServiceImp() as Service }
+   
+   //Register unique ServiceImp as Service
    container.register(.Unique) { ServiceImp() as Service }
+   
+   //Register ClientImp as Client and resolve it's service dependency
    container.register { try ClientImp(service: container.resolve() as Service) as Client }
+   
+   //Register ServiceImp as concrete type
+   container.register { ServiceImp() }
+   container.register(factory: ServiceImp.init)
+   
+   //Register ServiceImp as Service
+   container.register(Service.self, factory: ServiceImp.init)
+   
+   //Register ClientImp as Client
+   container.register(Client.self, factory: ClientImp.init(service:))
    ```
    */
-  public func register<T>(scope: ComponentScope = .Shared, tag: DependencyTagConvertible? = nil, factory: () throws -> T) -> Definition<T, ()> {
+  public func register<T>(scope: ComponentScope = .Shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: () throws -> T) -> Definition<T, ()> {
     let definition = DefinitionBuilder<T, ()> {
       $0.scope = scope
       $0.factory = factory
@@ -275,7 +295,7 @@ extension DependencyContainer {
     register(definition, forTag: tag)
     return definition
   }
-  
+
   /**
    Register generic factory and auto-wiring factory and associate it with an optional tag.
    

--- a/Sources/RuntimeArguments.swift
+++ b/Sources/RuntimeArguments.swift
@@ -42,7 +42,7 @@ extension DependencyContainer {
   
   - seealso: `registerFactory(tag:scope:factory:)`
   */
-  public func register<T, A>(scope: ComponentScope = .Shared, tag: DependencyTagConvertible? = nil, factory: (A) throws -> T) -> Definition<T, A> {
+  public func register<T, A>(scope: ComponentScope = .Shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: (A) throws -> T) -> Definition<T, A> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 1) { container, tag in try factory(container.resolve(tag: tag)) }
   }
   
@@ -82,7 +82,7 @@ extension DependencyContainer {
   // MARK: 2 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, A, B>(scope: ComponentScope = .Shared, tag: DependencyTagConvertible? = nil, factory: (A, B) throws -> T) -> Definition<T, (A, B)> {
+  public func register<T, A, B>(scope: ComponentScope = .Shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: (A, B) throws -> T) -> Definition<T, (A, B)> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 2) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   
@@ -99,7 +99,7 @@ extension DependencyContainer {
   // MARK: 3 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, A, B, C>(scope: ComponentScope = .Shared, tag: DependencyTagConvertible? = nil, factory: (A, B, C) throws -> T) -> Definition<T, (A, B, C)> {
+  public func register<T, A, B, C>(scope: ComponentScope = .Shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: (A, B, C) throws -> T) -> Definition<T, (A, B, C)> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 3)  { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   
@@ -116,7 +116,7 @@ extension DependencyContainer {
   // MARK: 4 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, A, B, C, D>(scope: ComponentScope = .Shared, tag: DependencyTagConvertible? = nil, factory: (A, B, C, D) throws -> T) -> Definition<T, (A, B, C, D)> {
+  public func register<T, A, B, C, D>(scope: ComponentScope = .Shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: (A, B, C, D) throws -> T) -> Definition<T, (A, B, C, D)> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 4) { container, tag in try factory(container.resolve(tag: tag),  container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   
@@ -133,7 +133,7 @@ extension DependencyContainer {
   // MARK: 5 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, A, B, C, D, E>(scope: ComponentScope = .Shared, tag: DependencyTagConvertible? = nil, factory: (A, B, C, D, E) throws -> T) -> Definition<T, (A, B, C, D, E)> {
+  public func register<T, A, B, C, D, E>(scope: ComponentScope = .Shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: (A, B, C, D, E) throws -> T) -> Definition<T, (A, B, C, D, E)> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 5) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   
@@ -150,7 +150,7 @@ extension DependencyContainer {
   // MARK: 6 Runtime Arguments
   
   /// - seealso: `register(tag:scope:factory:)`
-  public func register<T, A, B, C, D, E, F>(scope: ComponentScope = .Shared, tag: DependencyTagConvertible? = nil, factory: (A, B, C, D, E, F) throws -> T) -> Definition<T, (A, B, C, D, E, F)> {
+  public func register<T, A, B, C, D, E, F>(scope: ComponentScope = .Shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: (A, B, C, D, E, F) throws -> T) -> Definition<T, (A, B, C, D, E, F)> {
     return registerFactory(tag: tag, scope: scope, factory: factory, numberOfArguments: 6) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
   }
   


### PR DESCRIPTION
With that it is possible to register abstractions using methods of concrete type. Without it it is only possible to register concrete types using method instead of closure, like this:

```swift
container.register(factory: ServiceImp.init)
try container.resolve() as Service //fails
try container.resolve() as ServiceImp //succeeds
```

With explicit type parameter it is possible to register abstractions the same way as when using closures:

```swift
container.register(type: Service.self, factory: ServiceImp.init)
try container.resolve() as Service //succeeds
try container.resolve() as ServiceImp //fails
```

`type` parameter is optional and by default is inferred from the return type of the factory. It is even not used in during registration, it just provides compiler with explicit type to register instead of using inferred type.

With that it becomes much easier to register components with dependencies to be resolved by auto-wiring without needing to register them as concrete types.