### PR TITLE
Properly handling inheritance

### DIFF
--- a/Sources/AutoInjection.swift
+++ b/Sources/AutoInjection.swift
@@ -28,7 +28,18 @@ extension DependencyContainer {
    Resolves properties of passed object wrapped with `Injected<T>` or `InjectedWeak<T>`
    */
   func autoInjectProperties(instance: Any) throws {
-    try Mirror(reflecting: instance).children.forEach(resolveChild)
+    let mirror = Mirror(reflecting: instance)
+    
+    //mirror only containes class own properties
+    //so we need to walk throw super class mirrors
+    //to resolve super class auto-injected properties
+    var superClassMirror = mirror.superclassMirror()
+    while superClassMirror != nil {
+      try superClassMirror?.children.forEach(resolveChild)
+      superClassMirror = superClassMirror?.superclassMirror()
+    }
+    
+    try mirror.children.forEach(resolveChild)
   }
   
   private func resolveChild(child: Mirror.Child) throws {

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -292,6 +292,7 @@ extension DependencyContainer {
       $0.scope = scope
       $0.factory = factory
     }.build()
+    print("\(T.self)")
     register(definition, forTag: tag)
     return definition
   }
@@ -504,6 +505,7 @@ extension DependencyContainer {
 
     if let resolvable = resolvedInstance as? Resolvable {
       resolvedInstances.resolvableInstances.append(resolvable)
+      resolvable.resolveDependencies(self)
     }
 
     try autoInjectProperties(resolvedInstance)
@@ -745,10 +747,18 @@ extension DependencyContainer: CustomStringConvertible {
 
 //MARK: - Resolvable
 
-/// Conform to this protocol when you need to have a callback when all the dependencies are injected.
+/// Resolvable protocol provides some extension points for resolving dependencies with property injection.
 public protocol Resolvable {
-  /// This method is called by the container when all dependencies of the instance are resolved.
+  /// This method will be called right after instance is created by the container.
+  func resolveDependencies(container: DependencyContainer)
+  /// This method will be called when all dependencies of the instance are resolved.
+  /// When resolving objects graph the last resolved instance will receive this callback first.
   func didResolveDependencies()
+}
+
+extension Resolvable {
+  func resolveDependencies(container: DependencyContainer) { }
+  func didResolveDependencies() { }
 }
 
 //MARK: - DependencyTagConvertible

--- a/Sources/TypeForwarding.swift
+++ b/Sources/TypeForwarding.swift
@@ -64,6 +64,8 @@ extension Definition {
    - returns: definition on which `implements` was called
    */
   public func implements<F>(type: F.Type, tag: DependencyTagConvertible? = nil, resolvingProperties: (DependencyContainer, F) throws -> ()) -> Definition {
+    precondition(container != nil, "Definition should be registered in the container.")
+    
     let forwardDefinition = container!.register(self, type: type, tag: tag)
     forwardDefinition.resolvingProperties(resolvingProperties)
     return self

--- a/Tests/Dip/DipTests.swift
+++ b/Tests/Dip/DipTests.swift
@@ -65,6 +65,7 @@ class DipTests: XCTestCase {
       ("testThatItThrowsErrorIfFailsToResolveDependency", testThatItThrowsErrorIfFailsToResolveDependency),
       ("testThatItCallsDidResolveDependenciesOnResolvableIntance", testThatItCallsDidResolveDependenciesOnResolvableIntance),
       ("testThatItCallsDidResolveDependenciesInReverseOrder", testThatItCallsDidResolveDependenciesInReverseOrder),
+      ("testItCallsResolveDependenciesOnResolableInstance", testItCallsResolveDependenciesOnResolableInstance),
       ("testThatItResolvesCircularDependencies", testThatItResolvesCircularDependencies),
       ("testContainerCollaborators", testContainerCollaborators)
     ]
@@ -450,6 +451,36 @@ class DipTests: XCTestCase {
     //then
     XCTAssertTrue(ResolvableService.resolved.first === service2)
     XCTAssertTrue(ResolvableService.resolved.last === service1)
+  }
+  
+  func testItCallsResolveDependenciesOnResolableInstance() {
+    
+    class Class: Resolvable {
+      var resolveDependenciesCalled = false
+      
+      func resolveDependencies(container: DependencyContainer) {
+        resolveDependenciesCalled = true
+      }
+    }
+    
+    class SubClass: Class {
+      override func resolveDependencies(container: DependencyContainer) {
+        super.resolveDependencies(container)
+      }
+    }
+    
+    container.register { Class() }
+      .resolvingProperties { _, instance in
+        XCTAssertTrue(instance.resolveDependenciesCalled)
+    }
+    
+    container.register { SubClass() }
+      .resolvingProperties { _, instance in
+        XCTAssertTrue(instance.resolveDependenciesCalled)
+    }
+    
+    let _ = try! container.resolve() as Class
+    let _ = try! container.resolve() as SubClass
   }
   
   func testThatItResolvesCircularDependencies() {


### PR DESCRIPTION
* Fixed auto-injection to ensure that inherited auto-injected properties are resolved.
* Added `resolveDependencies(_:DependencyContainer)` method in `Resolvable` protocol for reusing dependencies resolution when inheriting.

Resolves #69 