### PR TITLE
Simplified auto-wiring

### DIFF
--- a/DipPlayground.playground/Pages/Auto-wiring.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Auto-wiring.xcplaygroundpage/Contents.swift
@@ -109,7 +109,7 @@ You don't need to call `resolve` in a factory and care about order of arguments 
 
 The only requirement is that all constructor arguments should be registered in the container and there should be no several factories with the same _number_ of arguments registered for the same components. 
 
-In very rare case when you have several different factories with different set of runtime arguments registered for the same component, when you try to resolve it container will try to use these factories one by one until one of them succeeds starting with a factory with most numbers of arguments. If it finds two factories with the same number of arguments it will throw an error.
+In very rare cases when you have several factories for the same component with different set of runtime arguments, when you try to resolve it container will try to use factory registered for the same type and tag (if provided, otherwise registered without tag) and with the maximum number of runtime arguments. If it finds two factories registered for the same type and tag and with the same number but different types of arguments it will throw an error.
 
 You can use auto-wiring with tags. The tag that you pass to `resolve` method will be used to resolve each of the constructor arguments.
 */

--- a/Sources/AutoInjection.swift
+++ b/Sources/AutoInjection.swift
@@ -30,8 +30,8 @@ extension DependencyContainer {
   func autoInjectProperties(instance: Any) throws {
     let mirror = Mirror(reflecting: instance)
     
-    //mirror only containes class own properties
-    //so we need to walk throw super class mirrors
+    //mirror only contains class own properties
+    //so we need to walk through super class mirrors
     //to resolve super class auto-injected properties
     var superClassMirror = mirror.superclassMirror()
     while superClassMirror != nil {


### PR DESCRIPTION
To simplify implementation of auto-wiring and remove some indirection in what definition will be used to auto-wire components container will form now on always use definition with a factory that accepts most number of arguments and matches tag (if provided) instead of iterating over definitions for the same type in order of decreasing arguments number. In practice in most of the cases there will be one definition per components, so that just adds computational and code complexity. 

Rarely there could be ambiguous definitions when the same component is registered for the same tag with the same number but different types of runtime arguments.