### PR TITLE
Fix compile error when building with Xcode8/Swift 3 GM

### DIFF
--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -184,7 +184,7 @@ public protocol DefinitionType: class { }
 public final class Definition<T, U>: DefinitionType {
   public typealias F = (U) throws -> T
   
-  init(scope: ComponentScope, factory: F) {
+  init(scope: ComponentScope, factory: @escaping F) {
     self.factory = factory
     self.scope = scope
   }


### PR DESCRIPTION
Apple Swift version 3.0 (swiftlang-800.0.46.2 clang-800.0.38)

The GM compiler introduces compile error this submission addresses.