### PR TITLE
Swift 2.3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,25 @@ matrix:
         - tar xzf $SWIFT_VERSION-ubuntu14.04.tar.gz
         - export PATH="${PWD}/${SWIFT_VERSION}-ubuntu14.04/usr/bin:${PATH}"
         - cd Dip
+    - script:
+        - swift build --clean && swift build
+      os: linux
+      dist: trusty
+      sudo: required
+      language: generic
+      before_install:
+        - wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
+        - cd ..
+        - export SWIFT_VERSION=swift-DEVELOPMENT-SNAPSHOT-2016-09-07-a
+        - wget https://swift.org/builds/development/ubuntu1404/$SWIFT_VERSION/$SWIFT_VERSION-ubuntu14.04.tar.gz
+        - tar xzf $SWIFT_VERSION-ubuntu14.04.tar.gz
+        - export PATH="${PWD}/${SWIFT_VERSION}-ubuntu14.04/usr/bin:${PATH}"
+        - export SWIFT_RELEASE_VERSION=2.2.1
+        - export SWIFT_RELEASE_NAME="${SWIFT_RELEASE_VERSION}-RELEASE"
+        - wget https://swift.org/builds/swift-$SWIFT_RELEASE_VERSION-release/ubuntu1404/swift-$SWIFT_RELEASE_NAME/swift-$SWIFT_RELEASE_NAME-ubuntu14.04.tar.gz
+        - tar xzf swift-$SWIFT_RELEASE_NAME-ubuntu14.04.tar.gz
+        - export SWIFT_EXEC="${PWD}/swift-${SWIFT_RELEASE_NAME}-ubuntu14.04/usr/bin/swiftc"
+        - cd Dip 
 
 notifications:
   email: false

--- a/Dip/Dip.xcodeproj/project.pbxproj
+++ b/Dip/Dip.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0919F4D61C16417B00DC3B10 /* RuntimeArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0919F4CC1C16417000DC3B10 /* RuntimeArguments.swift */; };
 		095F829C1D043B41008CD706 /* TypeForwarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095F829B1D043B41008CD706 /* TypeForwarding.swift */; };
 		0982AF0C1C5183A000B62463 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0982AF0B1C5183A000B62463 /* Utils.swift */; };
+		09871B411DAA6BF300B40B91 /* Compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09871B401DAA6BF300B40B91 /* Compatibility.swift */; };
 		09873F561C1E0237000C02F6 /* AutoInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09873F551C1E0237000C02F6 /* AutoInjection.swift */; };
 		09B036001C5D2B83001EA5B7 /* AutoWiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B035FF1C5D2B83001EA5B7 /* AutoWiring.swift */; };
 		09BD350E1D84E30D00B33E53 /* AutoInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09BD35041D84E30D00B33E53 /* AutoInjectionTests.swift */; };
@@ -26,6 +27,17 @@
 		09BD35151D84E30D00B33E53 /* ThreadSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09BD350B1D84E30D00B33E53 /* ThreadSafetyTests.swift */; };
 		09BD35161D84E30D00B33E53 /* TypeForwardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09BD350C1D84E30D00B33E53 /* TypeForwardingTests.swift */; };
 		09BD35171D84E30D00B33E53 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09BD350D1D84E30D00B33E53 /* Utils.swift */; };
+		09FC48061DAA9AC700566AA8 /* Resolve_swift2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FC48041DAA9AC700566AA8 /* Resolve_swift2.swift */; };
+		09FC48071DAA9AC700566AA8 /* Resolve.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FC48051DAA9AC700566AA8 /* Resolve.swift */; };
+		09FC480F1DAA9CAF00566AA8 /* Register.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FC480C1DAA9CAF00566AA8 /* Register.swift */; };
+		09FC48101DAA9CAF00566AA8 /* Register_swift2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FC480D1DAA9CAF00566AA8 /* Register_swift2.swift */; };
+		09FC48141DAA9E0200566AA8 /* AutoInjection_swift2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FC48121DAA9E0200566AA8 /* AutoInjection_swift2.swift */; };
+		09FC48181DAAA53100566AA8 /* DipError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FC48161DAAA53100566AA8 /* DipError.swift */; };
+		09FC48191DAAA53100566AA8 /* DipError_swift2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FC48171DAAA53100566AA8 /* DipError_swift2.swift */; };
+		09FC481B1DAAA82800566AA8 /* RuntimeArguments_swift2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FC481A1DAAA82800566AA8 /* RuntimeArguments_swift2.swift */; };
+		09FC481E1DAAA8F900566AA8 /* ComponentScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FC481C1DAAA8F900566AA8 /* ComponentScope.swift */; };
+		09FC481F1DAAA8F900566AA8 /* ComponentScope_swift2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FC481D1DAAA8F900566AA8 /* ComponentScope_swift2.swift */; };
+		09FC48211DAAAC4700566AA8 /* TypeForwarding_swift2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09FC48201DAAAC4700566AA8 /* TypeForwarding_swift2.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +61,7 @@
 		0919F4D11C16417000DC3B10 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		095F829B1D043B41008CD706 /* TypeForwarding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TypeForwarding.swift; path = ../../Sources/TypeForwarding.swift; sourceTree = "<group>"; };
 		0982AF0B1C5183A000B62463 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Utils.swift; path = ../../Sources/Utils.swift; sourceTree = "<group>"; };
+		09871B401DAA6BF300B40B91 /* Compatibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Compatibility.swift; path = ../../Sources/Compatibility.swift; sourceTree = "<group>"; };
 		09873F551C1E0237000C02F6 /* AutoInjection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AutoInjection.swift; path = ../../Sources/AutoInjection.swift; sourceTree = "<group>"; };
 		09B035FF1C5D2B83001EA5B7 /* AutoWiring.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AutoWiring.swift; path = ../../Sources/AutoWiring.swift; sourceTree = "<group>"; };
 		09BD35041D84E30D00B33E53 /* AutoInjectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AutoInjectionTests.swift; path = ../../Tests/DipTests/AutoInjectionTests.swift; sourceTree = "<group>"; };
@@ -61,6 +74,17 @@
 		09BD350B1D84E30D00B33E53 /* ThreadSafetyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ThreadSafetyTests.swift; path = ../../Tests/DipTests/ThreadSafetyTests.swift; sourceTree = "<group>"; };
 		09BD350C1D84E30D00B33E53 /* TypeForwardingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TypeForwardingTests.swift; path = ../../Tests/DipTests/TypeForwardingTests.swift; sourceTree = "<group>"; };
 		09BD350D1D84E30D00B33E53 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Utils.swift; path = ../../Tests/DipTests/Utils.swift; sourceTree = "<group>"; };
+		09FC48041DAA9AC700566AA8 /* Resolve_swift2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Resolve_swift2.swift; path = ../../Sources/Resolve_swift2.swift; sourceTree = "<group>"; };
+		09FC48051DAA9AC700566AA8 /* Resolve.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Resolve.swift; path = ../../Sources/Resolve.swift; sourceTree = "<group>"; };
+		09FC480C1DAA9CAF00566AA8 /* Register.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Register.swift; path = ../../Sources/Register.swift; sourceTree = "<group>"; };
+		09FC480D1DAA9CAF00566AA8 /* Register_swift2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Register_swift2.swift; path = ../../Sources/Register_swift2.swift; sourceTree = "<group>"; };
+		09FC48121DAA9E0200566AA8 /* AutoInjection_swift2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AutoInjection_swift2.swift; path = ../../Sources/AutoInjection_swift2.swift; sourceTree = "<group>"; };
+		09FC48161DAAA53100566AA8 /* DipError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DipError.swift; path = ../../Sources/DipError.swift; sourceTree = "<group>"; };
+		09FC48171DAAA53100566AA8 /* DipError_swift2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DipError_swift2.swift; path = ../../Sources/DipError_swift2.swift; sourceTree = "<group>"; };
+		09FC481A1DAAA82800566AA8 /* RuntimeArguments_swift2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RuntimeArguments_swift2.swift; path = ../../Sources/RuntimeArguments_swift2.swift; sourceTree = "<group>"; };
+		09FC481C1DAAA8F900566AA8 /* ComponentScope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ComponentScope.swift; path = ../../Sources/ComponentScope.swift; sourceTree = "<group>"; };
+		09FC481D1DAAA8F900566AA8 /* ComponentScope_swift2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ComponentScope_swift2.swift; path = ../../Sources/ComponentScope_swift2.swift; sourceTree = "<group>"; };
+		09FC48201DAAAC4700566AA8 /* TypeForwarding_swift2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TypeForwarding_swift2.swift; path = ../../Sources/TypeForwarding_swift2.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,12 +111,24 @@
 			children = (
 				0919F4C91C16417000DC3B10 /* Dip.h */,
 				0919F4CA1C16417000DC3B10 /* Dip.swift */,
+				09FC48161DAAA53100566AA8 /* DipError.swift */,
+				09FC48171DAAA53100566AA8 /* DipError_swift2.swift */,
+				09FC480C1DAA9CAF00566AA8 /* Register.swift */,
+				09FC480D1DAA9CAF00566AA8 /* Register_swift2.swift */,
+				09FC48051DAA9AC700566AA8 /* Resolve.swift */,
+				09FC48041DAA9AC700566AA8 /* Resolve_swift2.swift */,
 				0919F4C81C16417000DC3B10 /* Definition.swift */,
+				09FC481C1DAAA8F900566AA8 /* ComponentScope.swift */,
+				09FC481D1DAAA8F900566AA8 /* ComponentScope_swift2.swift */,
 				0919F4CC1C16417000DC3B10 /* RuntimeArguments.swift */,
+				09FC481A1DAAA82800566AA8 /* RuntimeArguments_swift2.swift */,
 				09873F551C1E0237000C02F6 /* AutoInjection.swift */,
+				09FC48121DAA9E0200566AA8 /* AutoInjection_swift2.swift */,
 				09B035FF1C5D2B83001EA5B7 /* AutoWiring.swift */,
 				095F829B1D043B41008CD706 /* TypeForwarding.swift */,
+				09FC48201DAAAC4700566AA8 /* TypeForwarding_swift2.swift */,
 				0982AF0B1C5183A000B62463 /* Utils.swift */,
+				09871B401DAA6BF300B40B91 /* Compatibility.swift */,
 				0919F4CB1C16417000DC3B10 /* Info.plist */,
 			);
 			path = Dip;
@@ -246,13 +282,25 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				09871B411DAA6BF300B40B91 /* Compatibility.swift in Sources */,
 				0982AF0C1C5183A000B62463 /* Utils.swift in Sources */,
+				09FC481F1DAAA8F900566AA8 /* ComponentScope_swift2.swift in Sources */,
 				0919F4D51C16417B00DC3B10 /* Definition.swift in Sources */,
+				09FC48061DAA9AC700566AA8 /* Resolve_swift2.swift in Sources */,
+				09FC48101DAA9CAF00566AA8 /* Register_swift2.swift in Sources */,
+				09FC48191DAAA53100566AA8 /* DipError_swift2.swift in Sources */,
+				09FC481E1DAAA8F900566AA8 /* ComponentScope.swift in Sources */,
+				09FC48211DAAAC4700566AA8 /* TypeForwarding_swift2.swift in Sources */,
 				09B036001C5D2B83001EA5B7 /* AutoWiring.swift in Sources */,
 				0919F4D41C16417B00DC3B10 /* Dip.swift in Sources */,
+				09FC481B1DAAA82800566AA8 /* RuntimeArguments_swift2.swift in Sources */,
+				09FC480F1DAA9CAF00566AA8 /* Register.swift in Sources */,
+				09FC48071DAA9AC700566AA8 /* Resolve.swift in Sources */,
 				095F829C1D043B41008CD706 /* TypeForwarding.swift in Sources */,
 				09873F561C1E0237000C02F6 /* AutoInjection.swift in Sources */,
+				09FC48181DAAA53100566AA8 /* DipError.swift in Sources */,
 				0919F4D61C16417B00DC3B10 /* RuntimeArguments.swift in Sources */,
+				09FC48141DAA9E0200566AA8 /* AutoInjection_swift2.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/AutoInjection_swift2.swift
+++ b/Sources/AutoInjection_swift2.swift
@@ -1,0 +1,98 @@
+//
+// Dip
+//
+// Copyright (c) 2015 Olivier Halligon <olivier@halligon.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#if !swift(>=3.0)
+  extension Injected {
+    
+    /**
+     Creates a new wrapper for auto-injected property.
+     
+     - parameters:
+        - required: Defines if the property is required or not.
+                    If container fails to inject required property it will als fail to resolve
+                    the instance that defines that property. Default is `true`.
+        - tag: An optional tag to use to lookup definitions when injecting this property. Default is `nil`.
+        - didInject: block that will be called when concrete instance is injected in this property.
+                     Similar to `didSet` property observer. Default value does nothing.
+     */
+    public convenience init(required: Bool = true, didInject: (T) -> () = { _ in }) {
+      self.init(value: nil, required: required, tag: nil, overrideTag: false, didInject: didInject)
+    }
+    
+    public convenience init(required: Bool = true, tag: DependencyTagConvertible?, didInject: (T) -> () = { _ in }) {
+      self.init(value: nil, required: required, tag: tag, overrideTag: true, didInject: didInject)
+    }
+    
+    
+    public func resolve(container: DependencyContainer) throws {
+      let resolved: T? = try super.resolve(with: container)
+      value = resolved
+    }
+  
+    /// Returns a new wrapper with provided value.
+    public func setValue(value: T?) -> Injected {
+      guard (required && value != nil) || !required else {
+        fatalError("Can not set required property to nil.")
+      }
+      return Injected(value: value, required: required, tag: tag, overrideTag: overrideTag, didInject: didInject)
+    }
+
+  }
+  
+  extension InjectedWeak {
+    
+    /**
+     Creates a new wrapper for weak auto-injected property.
+     
+     - parameters:
+        - required: Defines if the property is required or not.
+                    If container fails to inject required property it will als fail to resolve
+                    the instance that defines that property. Default is `true`.
+        - tag: An optional tag to use to lookup definitions when injecting this property. Default is `nil`.
+        - didInject: block that will be called when concrete instance is injected in this property.
+                     Similar to `didSet` property observer. Default value does nothing.
+     */
+    public convenience init(required: Bool = true, didInject: (T) -> () = { _ in }) {
+      self.init(value: nil, required: required, tag: nil, overrideTag: false, didInject: didInject)
+    }
+    
+    public convenience init(required: Bool = true, tag: DependencyTagConvertible?, didInject: (T) -> () = { _ in }) {
+      self.init(value: nil, required: required, tag: tag, overrideTag: true, didInject: didInject)
+    }
+    
+    public func resolve(container: DependencyContainer) throws {
+      let resolved: T? = try super.resolve(with: container)
+      valueBox = resolved.map(WeakBox.init)
+    }
+  
+    /// Returns a new wrapper with provided value.
+    public func setValue(value: T?) -> InjectedWeak {
+      guard (required && value != nil) || !required else {
+        fatalError("Can not set required property to nil.")
+      }
+      return InjectedWeak(value: value, required: required, tag: tag, overrideTag: overrideTag, didInject: didInject)
+    }
+
+  }
+#endif

--- a/Sources/Compatibility.swift
+++ b/Sources/Compatibility.swift
@@ -1,0 +1,75 @@
+#if swift(>=3.0)
+  extension Mirror {
+    var _superclassMirror: Mirror? {
+      return superclassMirror
+    }
+  }
+#else
+  public typealias Error = ErrorType
+  public typealias ExpressibleByIntegerLiteral = IntegerLiteralConvertible
+  public typealias ExpressibleByStringLiteral = StringLiteralConvertible
+  
+  extension CollectionType {
+    func sorted(@noescape by isOrderedBefore: (Self.Generator.Element, Self.Generator.Element) -> Bool) -> [Self.Generator.Element] {
+      return sort(isOrderedBefore)
+    }
+    
+    func contains(@noescape where predicate: (Self.Generator.Element) throws -> Bool) rethrows -> Bool {
+      return try contains(predicate)
+    }
+  }
+  
+  extension CollectionType where Index : RandomAccessIndexType {
+    @warn_unused_result
+    public func reversed() -> ReverseRandomAccessCollection<Self> {
+      return reverse()
+    }
+  }
+
+  extension SequenceType where Generator.Element == String {
+    @warn_unused_result
+    public func joined(separator aSeparator: String) -> String {
+      return joinWithSeparator(aSeparator)
+    }
+  }
+  
+  extension Array {
+    public mutating func append<C : CollectionType where C.Generator.Element == Element>(contentsOf newElements: C) {
+      appendContentsOf(newElements)
+    }
+    public mutating func append<S : SequenceType where S.Generator.Element == Element>(contentsOf newElements: S) {
+      appendContentsOf(newElements)
+    }
+  }
+  
+  extension Mirror {
+    var _superclassMirror: Mirror? {
+      return superclassMirror()
+    }
+  }
+  
+  extension String {
+    init(describing thing: Any) {
+      self.init(thing)
+    }
+  }
+  
+#endif
+
+#if _runtime(_ObjC)
+  extension String {
+    public func has(prefix aPrefix: String) -> Bool {
+      return hasPrefix(aPrefix)
+    }
+  }
+  
+#else
+  
+  extension String {
+    public func has(prefix aPrefix: String) -> Bool {
+      return aPrefix ==
+        String(self.characters.prefix(aPrefix.characters.count))
+    }
+
+  }
+#endif

--- a/Sources/ComponentScope.swift
+++ b/Sources/ComponentScope.swift
@@ -1,0 +1,124 @@
+//
+// Dip
+//
+// Copyright (c) 2015 Olivier Halligon <olivier@halligon.net>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#if swift(>=3.0)
+
+  ///Component scope defines a strategy used by the `DependencyContainer` to manage resolved instances life cycle.
+  public enum ComponentScope {
+    
+    /**
+     A new instance will be created every time it's resolved.
+     This is a default strategy. Use this strategy when you don't want instances to be shared
+     between different consumers (i.e. if it is not thread safe).
+     
+     **Example**:
+     
+     ```
+     container.register { ServiceImp() as Service }
+     container.register { 
+       ServiceConsumerImp(
+         service1: try container.resolve() as Service
+         service2: try container.resolve() as Service
+       ) as ServiceConsumer
+     }
+     let consumer = container.resolve() as ServiceConsumer
+     consumer.service1 !== consumer.service2 //true
+     
+     ```
+     */
+    case unique
+    
+    /**
+     Instance resolved with the same definition will be reused until topmost `resolve(tag:)` method returns.
+     When you resolve the same object graph again the container will create new instances.
+     Use this strategy if you want different object in objects graph to share the same instance.
+     
+     - warning: Make sure this component is thread safe or accessed always from the same thread.
+     
+     **Example**:
+     
+     ```
+     container.register { ServiceImp() as Service }
+     container.register {
+       ServiceConsumerImp(
+         service1: try container.resolve() as Service
+         service2: try container.resolve() as Service
+       ) as ServiceConsumer
+     }
+     let consumer1 = container.resolve() as ServiceConsumer
+     let consumer2 = container.resolve() as ServiceConsumer
+     consumer1.service1 === consumer1.service2 //true
+     consumer2.service1 === consumer2.service2 //true
+     consumer1.service1 !== consumer2.service1 //true
+     ```
+     */
+    case shared
+    
+    /**
+     Resolved instance will be retained by the container and always reused.
+     Do not mix this life cycle with _singleton pattern_.
+     Instance will be not shared between different containers unless they collaborate.
+     
+     - warning: Make sure this component is thread safe or accessed always from the same thread.
+     
+     - note: When you override or remove definition from the container an instance 
+             that was resolved with this definition will be released. When you reset 
+             the container it will release all singleton instances.
+     
+     **Example**:
+     
+     ```
+     container.register(.singleton) { ServiceImp() as Service }
+     container.register {
+       ServiceConsumerImp(
+         service1: try container.resolve() as Service
+         service2: try container.resolve() as Service
+       ) as ServiceConsumer
+     }
+     let consumer1 = container.resolve() as ServiceConsumer
+     let consumer2 = container.resolve() as ServiceConsumer
+     consumer1.service1 === consumer1.service2 //true
+     consumer2.service1 === consumer2.service2 //true
+     consumer1.service1 === consumer2.service1 //true
+     ```
+     */
+    case singleton
+    
+    /**
+     The same scope as a `Singleton`, but instance will be created when container is bootstrapped.
+     
+     - seealso: `bootstrap()`
+    */
+    case eagerSingleton
+    
+    /**
+     The same scope as a `Singleton`, but container stores week reference to the resolved instance.
+     While a strong reference to the resolved instance exists resolve will return the same instance.
+     After the resolved instance is deallocated next resolve will produce a new instance.
+    */
+    case weakSingleton
+    
+  }
+  
+#endif

--- a/Sources/ComponentScope_swift2.swift
+++ b/Sources/ComponentScope_swift2.swift
@@ -1,0 +1,129 @@
+//
+// Dip
+//
+// Copyright (c) 2015 Olivier Halligon <olivier@halligon.net>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#if !swift(>=3.0)
+
+  ///Component scope defines a strategy used by the `DependencyContainer` to manage resolved instances life cycle.
+  public enum ComponentScope {
+    
+    /**
+     A new instance will be created every time it's resolved.
+     This is a default strategy. Use this strategy when you don't want instances to be shared
+     between different consumers (i.e. if it is not thread safe).
+     
+     **Example**:
+     
+     ```
+     container.register { ServiceImp() as Service }
+     container.register {
+       ServiceConsumerImp(
+         service1: try container.resolve() as Service
+         service2: try container.resolve() as Service
+         ) as ServiceConsumer
+       }
+     let consumer = container.resolve() as ServiceConsumer
+     consumer.service1 !== consumer.service2 //true
+     
+     ```
+     */
+    case Unique
+    
+    /**
+     Instance resolved with the same definition will be reused until topmost `resolve(tag:)` method returns.
+     When you resolve the same object graph again the container will create new instances.
+     Use this strategy if you want different object in objects graph to share the same instance.
+     
+     - warning: Make sure this component is thread safe or accessed always from the same thread.
+     
+     **Example**:
+     
+     ```
+     container.register { ServiceImp() as Service }
+     container.register {
+       ServiceConsumerImp(
+         service1: try container.resolve() as Service
+         service2: try container.resolve() as Service
+       ) as ServiceConsumer
+     }
+     let consumer1 = container.resolve() as ServiceConsumer
+     let consumer2 = container.resolve() as ServiceConsumer
+     consumer1.service1 === consumer1.service2 //true
+     consumer2.service1 === consumer2.service2 //true
+     consumer1.service1 !== consumer2.service1 //true
+     ```
+     */
+    case Shared
+    
+    /**
+     Resolved instance will be retained by the container and always reused.
+     Do not mix this life cycle with _singleton pattern_.
+     Instance will be not shared between different containers unless they collaborate.
+     
+     - warning: Make sure this component is thread safe or accessed always from the same thread.
+     
+     - note: When you override or remove definition from the container an instance
+             that was resolved with this definition will be released. When you reset
+             the container it will release all singleton instances.
+     
+     **Example**:
+     
+     ```
+     container.register(.singleton) { ServiceImp() as Service }
+     container.register {
+       ServiceConsumerImp(
+         service1: try container.resolve() as Service
+         service2: try container.resolve() as Service
+       ) as ServiceConsumer
+     }
+     let consumer1 = container.resolve() as ServiceConsumer
+     let consumer2 = container.resolve() as ServiceConsumer
+     consumer1.service1 === consumer1.service2 //true
+     consumer2.service1 === consumer2.service2 //true
+     consumer1.service1 === consumer2.service1 //true
+     ```
+     */
+    case Singleton
+    
+    /**
+     The same scope as a `Singleton`, but instance will be created when container is bootstrapped.
+     
+     - seealso: `bootstrap()`
+     */
+    case EagerSingleton
+    
+    /**
+     The same scope as a `Singleton`, but container stores week reference to the resolved instance.
+     While a strong reference to the resolved instance exists resolve will return the same instance.
+     After the resolved instance is deallocated next resolve will produce a new instance.
+     */
+    case WeakSingleton
+  
+    static var unique: ComponentScope { return .Unique }
+    static var shared: ComponentScope { return .Shared }
+    static var singleton: ComponentScope { return .Singleton }
+    static var weakSingleton: ComponentScope { return .WeakSingleton }
+    static var eagerSingleton: ComponentScope { return .EagerSingleton }
+  }
+
+#endif

--- a/Sources/DipError.swift
+++ b/Sources/DipError.swift
@@ -1,0 +1,96 @@
+//
+// Dip
+//
+// Copyright (c) 2015 Olivier Halligon <olivier@halligon.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#if swift(>=3.0)
+/**
+ Errors thrown by `DependencyContainer`'s methods.
+ 
+ - seealso: `resolve(tag:)`
+ */
+public enum DipError: Error, CustomStringConvertible {
+  
+  /**
+   Thrown by `resolve(tag:)` if no matching definition was registered in container.
+   
+   - parameter key: definition key used to lookup matching definition
+   */
+  case definitionNotFound(key: DefinitionKey)
+  
+  /**
+   Thrown by `resolve(tag:)` if failed to auto-inject required property.
+   
+   - parameters:
+      - label: The name of the property
+      - type: The type of the property
+      - underlyingError: The error that caused auto-injection to fail
+   */
+  case autoInjectionFailed(label: String?, type: Any.Type, underlyingError: Error)
+  
+  /**
+   Thrown by `resolve(tag:)` if failed to auto-wire a type.
+   
+   - parameters:
+      - type: The type that failed to be resolved by auto-wiring
+      - underlyingError: The error that cause auto-wiring to fail
+   */
+  case autoWiringFailed(type: Any.Type, underlyingError: Error)
+  
+  /**
+   Thrown when auto-wiring type if several definitions with the same number of runtime arguments
+   are registered for that type.
+   
+   - parameters:
+      - type: The type that failed to be resolved by auto-wiring
+      - definitions: Ambiguous definitions
+   */
+  case ambiguousDefinitions(type: Any.Type, definitions: [DefinitionType])
+  
+  /**
+   Thrown by `resolve(tag:)` if resolved instance does not implemenet resolved type (i.e. when type-forwarding).
+   
+   - parameters:
+      - resolved: Resolved instance
+      - key: Definition key used to resolve instance
+   */
+  case invalidType(resolved: Any?, key: DefinitionKey)
+  
+  public var description: String {
+    switch self {
+    case let .definitionNotFound(key):
+      return "No definition registered for \(key).\nCheck the tag, type you try to resolve, number, order and types of runtime arguments passed to `resolve()` and match them with registered factories for type \(key.type)."
+    case let .autoInjectionFailed(label, type, error):
+      return "Failed to auto-inject property \"\(label.desc)\" of type \(type). \(error)"
+    case let .autoWiringFailed(type, error):
+      return "Failed to auto-wire type \"\(type)\". \(error)"
+    case let .ambiguousDefinitions(type, definitions):
+      return "Ambiguous definitions for \(type):\n" +
+        definitions.map({ "\($0)" }).joined(separator: ";\n")
+    case let .invalidType(resolved, key):
+      return "Resolved instance \(resolved ?? "nil") does not implement expected type \(key.type)."
+    }
+  }
+  
+}
+#endif
+

--- a/Sources/DipError_swift2.swift
+++ b/Sources/DipError_swift2.swift
@@ -1,0 +1,116 @@
+//
+// Dip
+//
+// Copyright (c) 2015 Olivier Halligon <olivier@halligon.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#if !swift(>=3.0)
+
+/**
+ Errors thrown by `DependencyContainer`'s methods.
+ 
+ - seealso: `resolve(tag:)`
+ */
+public enum DipError: Error, CustomStringConvertible {
+  
+  /**
+   Thrown by `resolve(tag:)` if no matching definition was registered in container.
+   
+   - parameter key: definition key used to lookup matching definition
+   */
+  case DefinitionNotFound(key: DefinitionKey)
+  
+  /**
+   Thrown by `resolve(tag:)` if failed to auto-inject required property.
+   
+   - parameters:
+      - label: The name of the property
+      - type: The type of the property
+      - underlyingError: The error that caused auto-injection to fail
+   */
+  case AutoInjectionFailed(label: String?, type: Any.Type, underlyingError: Error)
+  
+  /**
+   Thrown by `resolve(tag:)` if failed to auto-wire a type.
+   
+   - parameters:
+      - type: The type that failed to be resolved by auto-wiring
+      - underlyingError: The error that cause auto-wiring to fail
+   */
+  case AutoWiringFailed(type: Any.Type, underlyingError: Error)
+  
+  /**
+   Thrown when auto-wiring type if several definitions with the same number of runtime arguments
+   are registered for that type.
+   
+   - parameters:
+      - type: The type that failed to be resolved by auto-wiring
+      - definitions: Ambiguous definitions
+   */
+  case AmbiguousDefinitions(type: Any.Type, definitions: [DefinitionType])
+  
+  /**
+   Thrown by `resolve(tag:)` if resolved instance does not implemenet resolved type (i.e. when type-forwarding).
+   
+   - parameters:
+      - resolved: Resolved instance
+      - key: Definition key used to resolve instance
+   */
+  case InvalidType(resolved: Any?, key: DefinitionKey)
+  
+  public var description: String {
+    switch self {
+    case let .DefinitionNotFound(key):
+      return "No definition registered for \(key).\nCheck the tag, type you try to resolve, number, order and types of runtime arguments passed to `resolve()` and match them with registered factories for type \(key.type)."
+    case let .AutoInjectionFailed(label, type, error):
+      return "Failed to auto-inject property \"\(label.desc)\" of type \(type). \(error)"
+    case let .AutoWiringFailed(type, error):
+      return "Failed to auto-wire type \"\(type)\". \(error)"
+    case let .AmbiguousDefinitions(type, definitions):
+      return "Ambiguous definitions for \(type):\n" +
+        definitions.map({ "\($0)" }).joined(separator: ";\n")
+    case let .InvalidType(resolved, key):
+      return "Resolved instance \(resolved ?? "nil") does not implement expected type \(key.type)."
+    }
+  }
+
+  static func definitionNotFound(key aKey: DefinitionKey) -> DipError {
+    return DipError.DefinitionNotFound(key: aKey)
+  }
+  
+  static func autoInjectionFailed(label aLabel: String?, type: Any.Type, underlyingError: Error) -> DipError {
+    return DipError.AutoInjectionFailed(label: aLabel, type: type, underlyingError: underlyingError)
+  }
+  
+  static func autoWiringFailed(type aType: Any.Type, underlyingError: Error) -> DipError {
+    return DipError.AutoWiringFailed(type: aType, underlyingError: underlyingError)
+  }
+  
+  static func ambiguousDefinitions(type aType: Any.Type, definitions: [DefinitionType]) -> DipError {
+    return DipError.AmbiguousDefinitions(type: aType, definitions: definitions)
+  }
+  
+  static func invalidType(resolved _resolved: Any?, key: DefinitionKey) -> DipError {
+    return DipError.InvalidType(resolved: _resolved, key: key)
+  }
+}
+#endif
+

--- a/Sources/Register.swift
+++ b/Sources/Register.swift
@@ -1,0 +1,84 @@
+//
+// Dip
+//
+// Copyright (c) 2015 Olivier Halligon <olivier@halligon.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#if swift(>=3.0)
+  extension DependencyContainer {
+    /**
+     Registers definition for passed type.
+     
+     If instance created by factory of definition, passed as a first parameter,
+     does not implement type passed in a `type` parameter,
+     container will throw `DipError.DefinitionNotFound` error when trying to resolve that type.
+     
+     - parameters:
+        - definition: Definition to register
+        - type: Type to register definition for
+        - tag: Optional tag to associate definition with. Default is `nil`.
+     
+     - returns: New definition registered for passed type.
+     */
+    @discardableResult public func register<T, U, F>(_ definition: Definition<T, U>, type: F.Type, tag: DependencyTagConvertible? = nil) -> Definition<F, U> {
+      return _register(definition: definition, type: type, tag: tag)
+    }
+
+    /**
+     Register definiton in the container and associate it with an optional tag.
+     Will override already registered definition for the same type and factory, associated with the same tag.
+     
+     - parameters:
+        - tag: The arbitrary tag to associate this definition with. Pass `nil` to associate with any tag. Default value is `nil`.
+        - definition: The definition to register in the container.
+     
+     */
+    public func register<T, U>(_ definition: Definition<T, U>, tag: DependencyTagConvertible? = nil) {
+      _register(definition: definition, tag: tag)
+    }
+
+  }
+#endif
+
+extension DependencyContainer {
+  
+  func _register<T, U>(definition aDefinition: Definition<T, U>, tag: DependencyTagConvertible? = nil) {
+    precondition(!bootstrapped, "You can not modify container's definitions after it was bootstrapped.")
+    let definition = aDefinition
+    threadSafe {
+      let key = DefinitionKey(type: T.self, typeOfArguments: U.self, tag: tag?.dependencyTag)
+      if let _ = definitions[key] {
+        _remove(definitionForKey: key)
+      }
+      
+      definition.container = self
+      definitions[key] = definition
+      resolvedInstances.singletons[key] = nil
+      resolvedInstances.weakSingletons[key] = nil
+      
+      if .eagerSingleton == definition.scope {
+        bootstrapQueue.append({ _ = try self.resolve(tag: tag) as T })
+      }
+    }
+  }
+  
+}
+

--- a/Sources/Register_swift2.swift
+++ b/Sources/Register_swift2.swift
@@ -1,0 +1,59 @@
+//
+// Dip
+//
+// Copyright (c) 2015 Olivier Halligon <olivier@halligon.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#if !swift(>=3.0)
+  extension DependencyContainer {
+    /**
+     Registers definition for passed type.
+     
+     If instance created by factory of definition, passed as a first parameter,
+     does not implement type passed in a `type` parameter,
+     container will throw `DipError.DefinitionNotFound` error when trying to resolve that type.
+     
+     - parameters:
+        - definition: Definition to register
+        - type: Type to register definition for
+        - tag: Optional tag to associate definition with. Default is `nil`.
+     
+     - returns: New definition registered for passed type.
+     */
+    public func register<T, U, F>(definition: Definition<T, U>, type: F.Type, tag: DependencyTagConvertible? = nil) -> Definition<F, U> {
+      return _register(definition: definition, type: type, tag: tag)
+    }
+    
+    /**
+     Register definiton in the container and associate it with an optional tag.
+     Will override already registered definition for the same type and factory, associated with the same tag.
+     
+     - parameters:
+        - tag: The arbitrary tag to associate this definition with. Pass `nil` to associate with any tag. Default value is `nil`.
+        - definition: The definition to register in the container.
+     
+     */
+    public func register<T, U>(definition: Definition<T, U>, tag: DependencyTagConvertible? = nil) {
+      _register(definition: definition, tag: tag)
+    }
+  }
+#endif
+

--- a/Sources/Resolve.swift
+++ b/Sources/Resolve.swift
@@ -1,0 +1,293 @@
+//
+// Dip
+//
+// Copyright (c) 2015 Olivier Halligon <olivier@halligon.net>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#if swift(>=3.0)
+  extension DependencyContainer {
+    
+    /**
+     Resolve an instance of type `T`.
+     
+     If no matching definition was registered with provided `tag`,
+     container will lookup definition associated with `nil` tag.
+     
+     - parameter tag: The arbitrary tag to use to lookup definition.
+     
+     - throws: `DipError.DefinitionNotFound`, `DipError.AutoInjectionFailed`, `DipError.AmbiguousDefinitions`, `DipError.InvalidType`
+     
+     - returns: An instance of type `T`.
+     
+     **Example**:
+     ```swift
+     let service = try! container.resolve() as Service
+     let service = try! container.resolve(tag: "service") as Service
+     let service: Service = try! container.resolve()
+     ```
+     
+     - seealso: `register(_:type:tag:factory:)`
+     */
+    public func resolve<T>(tag: DependencyTagConvertible? = nil) throws -> T {
+      return try resolve(tag: tag) { factory in try factory() }
+    }
+
+    /**
+     Resolve an instance of requested type. Weakly-typed alternative of `resolve(tag:)`
+     
+     - warning: This method does not make any type checks, so there is no guaranty that
+                resulting instance is actually an instance of requested type.
+                That can happen if you register forwarded type that is not implemented by resolved instance.
+     
+     - parameters:
+        - type: Type to resolve
+        - tag: The arbitrary tag to use to lookup definition.
+     
+     - throws: `DipError.DefinitionNotFound`, `DipError.AutoInjectionFailed`, `DipError.AmbiguousDefinitions`, `DipError.InvalidType`
+     
+     - returns: An instance of requested type.
+
+     **Example**:
+     ```swift
+     let service = try! container.resolve(Service.self) as! Service
+     let service = try! container.resolve(Service.self, tag: "service") as! Service
+     ```
+
+     - seealso: `resolve(tag:)`, `register(_:type:tag:factory:)`
+     */
+    public func resolve(_ type: Any.Type, tag: DependencyTagConvertible? = nil) throws -> Any {
+      return try resolve(type, tag: tag) { factory in try factory() }
+    }
+    
+    /**
+     Resolve an instance of type `T` using generic builder closure that accepts generic factory and returns created instance.
+     
+     - parameters:
+        - tag: The arbitrary tag to use to lookup definition.
+        - builder: Generic closure that accepts generic factory and returns inctance created by that factory.
+     
+     - throws: `DipError.DefinitionNotFound`, `DipError.AutoInjectionFailed`, `DipError.AmbiguousDefinitions`, `DipError.InvalidType`
+     
+     - returns: An instance of type `T`.
+     
+     - note: You _should not_ call this method directly, instead call any of other 
+             `resolve(tag:)` or `resolve(tag:withArguments:)` methods.
+             You _should_ use this method only to resolve dependency with more runtime arguments than
+             _Dip_ supports (currently it's up to six) like in the following example:
+     
+     ```swift
+     public func resolve<T, A, B, C, ...>(tag: Tag? = nil, _ arg1: A, _ arg2: B, _ arg3: C, ...) throws -> T {
+       return try resolve(tag: tag) { factory in factory(arg1, arg2, arg3, ...) }
+     }
+     ```
+     
+     Though before you do so you should probably review your design and try to reduce the number of dependencies.
+     */
+    public func resolve<T, U>(tag: DependencyTagConvertible? = nil, builder: ((U) throws -> T) throws -> T) throws -> T {
+      return try _resolve(tag: tag, builder: builder)
+    }
+    
+    /**
+     Resolve an instance of provided type using builder closure. Weakly-typed alternative of `resolve(tag:builder:)`
+     
+     - seealso: `resolve(tag:builder:)`
+    */
+    public func resolve<U>(_ type: Any.Type, tag: DependencyTagConvertible? = nil, builder: ((U) throws -> Any) throws -> Any) throws -> Any {
+      return try _resolve(type: type, tag: tag, builder: builder)
+    }
+
+  }
+#endif
+
+extension DependencyContainer {
+  
+  func _resolve<T, U>(tag aTag: DependencyTagConvertible? = nil, builder: ((U) throws -> T) throws -> T) throws -> T {
+    return try resolve(T.self, tag: aTag, builder: { factory in
+      try builder({ try factory($0) as! T })
+    }) as! T
+  }
+  
+  func _resolve<U>(type aType: Any.Type, tag: DependencyTagConvertible? = nil, builder: ((U) throws -> Any) throws -> Any) throws -> Any {
+    let key = DefinitionKey(type: aType, typeOfArguments: U.self, tag: tag?.dependencyTag)
+    
+    return try inContext(key:key, injectedInType: context?.resolvingType) {
+      try self._resolve(key: key, builder: { definition in
+        try builder(definition.weakFactory)
+      })
+    }
+  }
+  
+  /// Lookup definition by the key and use it to resolve instance. Fallback to the key with `nil` tag.
+  func _resolve<T>(key aKey: DefinitionKey, builder: (_Definition) throws -> T) throws -> T {
+    guard let matching = self.definition(matching: aKey) else {
+      return try collaboratingResolve(key: aKey, builder: builder) ?? autowire(key: aKey)
+    }
+    
+    let (key, definition) = matching
+    
+    //first search for already resolved instance for this type or any of forwarding types
+    if let previouslyResolved: T = previouslyResolved(for: definition, key: key) {
+      log(level: .Verbose, "Reusing previously resolved instance \(previouslyResolved)")
+      return previouslyResolved
+    }
+    
+    log(level: .Verbose, context)
+    var resolvedInstance = try builder(definition)
+    
+    /*
+     Strongly-typed `resolve(tag:builder:)` calls weakly-typed `resolve(_:tag:builder:)`,
+     so `T` will be `Any` at runtime, erasing type information when this method returns.
+     When we try to cast result of `Any` to generic type T Swift fails to cast it.
+     The same happens in the following code snippet:
+     
+     let optService: Service? = ServiceImp()
+     let anyService: Any = optService
+     let service: Service = anyService as! Service
+     
+     That happens because when Optional is casted to Any Swift can not implicitly unwrap it with as operator.
+     As a workaround we detect boxing here and unwrap it so that we return not a box, but wrapped instance.
+     */
+    if let box = resolvedInstance as? BoxType, let unboxed = box.unboxed as? T {
+      resolvedInstance = unboxed
+    }
+    
+    //when builder calls factory it will in turn resolve sub-dependencies (if there are any)
+    //when it returns instance that we try to resolve here can be already resolved
+    //so we return it, throwing away instance created by previous call to builder
+    if let previouslyResolved: T = previouslyResolved(for: definition, key: key) {
+      log(level: .Verbose, "Reusing previously resolved instance \(previouslyResolved)")
+      return previouslyResolved
+    }
+    
+    resolvedInstances[key: key, inScope: definition.scope] = resolvedInstance
+    
+    if let resolvable = resolvedInstance as? Resolvable {
+      resolvedInstances.resolvableInstances.append(resolvable)
+      resolvable.resolveDependencies(self)
+    }
+    
+    try autoInjectProperties(in: resolvedInstance)
+    try definition.resolveProperties(of: resolvedInstance, container: self)
+    
+    log(level: .Verbose, "Resolved type \(key.type) with \(resolvedInstance)")
+    return resolvedInstance
+  }
+  
+  private func previouslyResolved<T>(for definition: _Definition, key: DefinitionKey) -> T? {
+    //first check if exact key was already resolved
+    if let previouslyResolved = resolvedInstances[key: key, inScope: definition.scope] as? T {
+      return previouslyResolved
+    }
+    //then check if any related type was already resolved
+    let keys = definition.implementingTypes.map({
+      DefinitionKey(type: $0, typeOfArguments: key.typeOfArguments, tag: key.tag)
+    })
+    for key in keys {
+      if let previouslyResolved = resolvedInstances[key: key, inScope: definition.scope] as? T {
+        return previouslyResolved
+      }
+    }
+    return nil
+  }
+  
+  /// Searches for definition that matches provided key
+  private func definition(matching key: DefinitionKey) -> KeyDefinitionPair? {
+    if let definition = (self.definitions[key] ?? self.definitions[key.tagged(with: nil)]) {
+      return (key, definition)
+    }
+    
+    //if no definition registered for exact type try to find type-forwarding definition that can resolve the type
+    //that will actually happen only when resolving optionals
+    if definitions.filter({ $0.0.type == key.type }).isEmpty {
+      return typeForwardingDefinition(forKey: key)
+    }
+    return nil
+  }
+  
+}
+
+///Pool to hold instances, created during call to `resolve()`.
+///Before `resolve()` returns pool is drained.
+class ResolvedInstances {
+  
+  var resolvedInstances = [DefinitionKey: Any]()
+  var resolvableInstances = [Resolvable]()
+  
+  //singletons are stored using reference type wrapper to be able to share them between containers
+  var singletonsBox = Box<[DefinitionKey: Any]>([:])
+  var singletons: [DefinitionKey: Any] {
+    get { return singletonsBox.unboxed }
+    set { singletonsBox.unboxed = newValue }
+  }
+  
+  var weakSingletonsBox = Box<[DefinitionKey: Any]>([:])
+  var weakSingletons: [DefinitionKey: Any] {
+    get { return weakSingletonsBox.unboxed }
+    set { weakSingletonsBox.unboxed = newValue }
+  }
+  
+  subscript(key key: DefinitionKey, inScope scope: ComponentScope) -> Any? {
+    get {
+      if scope == .singleton || scope == .eagerSingleton {
+        return singletons[key]
+      }
+      if scope == .weakSingleton {
+        if let boxed = weakSingletons[key] as? WeakBoxType { return boxed.unboxed }
+        else { return weakSingletons[key] }
+      }
+      if scope == .shared {
+        return resolvedInstances[key]
+      }
+      return nil
+    }
+    set {
+      if scope == .singleton || scope == .eagerSingleton {
+        singletons[key] = newValue
+      }
+      if scope == .weakSingleton {
+        weakSingletons[key] = newValue
+      }
+      if scope == .shared {
+        resolvedInstances[key] = newValue
+      }
+    }
+  }
+  
+}
+
+//MARK: - Resolvable
+
+#if swift(>=3.0)
+
+  /// Resolvable protocol provides some extension points for resolving dependencies with property injection.
+  public protocol Resolvable {
+    /// This method will be called right after instance is created by the container.
+    func resolveDependencies(_ container: DependencyContainer)
+    /// This method will be called when all dependencies of the instance are resolved.
+    /// When resolving objects graph the last resolved instance will receive this callback first.
+    func didResolveDependencies()
+  }
+  
+  extension Resolvable {
+    func resolveDependencies(_ container: DependencyContainer) {}
+    func didResolveDependencies() {}
+  }
+#endif

--- a/Sources/Resolve_swift2.swift
+++ b/Sources/Resolve_swift2.swift
@@ -1,0 +1,135 @@
+//
+// Dip
+//
+// Copyright (c) 2015 Olivier Halligon <olivier@halligon.net>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#if !swift(>=3.0)
+  extension DependencyContainer {
+    
+    /**
+     Resolve an instance of type `T`.
+     
+     If no matching definition was registered with provided `tag`,
+     container will lookup definition associated with `nil` tag.
+     
+     - parameter tag: The arbitrary tag to use to lookup definition.
+     
+     - throws: `DipError.DefinitionNotFound`, `DipError.AutoInjectionFailed`, `DipError.AmbiguousDefinitions`, `DipError.InvalidType`
+     
+     - returns: An instance of type `T`.
+     
+     **Example**:
+     ```swift
+     let service = try! container.resolve() as Service
+     let service = try! container.resolve(tag: "service") as Service
+     let service: Service = try! container.resolve()
+     ```
+     
+     - seealso: `register(_:type:tag:factory:)`
+     */
+    public func resolve<T>(tag tag: DependencyTagConvertible? = nil) throws -> T {
+      return try resolve(tag: tag) { factory in try factory() }
+    }
+    
+    /**
+     Resolve an instance of requested type. Weakly-typed alternative of `resolve(tag:)`
+     
+     - warning: This method does not make any type checks, so there is no guaranty that
+                resulting instance is actually an instance of requested type.
+                That can happen if you register forwarded type that is not implemented by resolved instance.
+     
+     - parameters:
+        - type: Type to resolve
+        - tag: The arbitrary tag to use to lookup definition.
+     
+     - throws: `DipError.DefinitionNotFound`, `DipError.AutoInjectionFailed`, `DipError.AmbiguousDefinitions`, `DipError.InvalidType`
+     
+     - returns: An instance of requested type.
+     
+     **Example**:
+     ```swift
+     let service = try! container.resolve(Service.self) as! Service
+     let service = try! container.resolve(Service.self, tag: "service") as! Service
+     ```
+     
+     - seealso: `resolve(tag:)`, `register(_:type:tag:factory:)`
+     */
+    public func resolve(type: Any.Type, tag: DependencyTagConvertible? = nil) throws -> Any {
+      return try resolve(type, tag: tag) { factory in try factory() }
+    }
+    
+    /**
+     Resolve an instance of type `T` using generic builder closure that accepts generic factory and returns created instance.
+     
+     - parameters:
+        - tag: The arbitrary tag to use to lookup definition.
+        - builder: Generic closure that accepts generic factory and returns inctance created by that factory.
+     
+     - throws: `DipError.DefinitionNotFound`, `DipError.AutoInjectionFailed`, `DipError.AmbiguousDefinitions`, `DipError.InvalidType`
+     
+     - returns: An instance of type `T`.
+     
+     - note: You _should not_ call this method directly, instead call any of other
+             `resolve(tag:)` or `resolve(tag:withArguments:)` methods.
+             You _should_ use this method only to resolve dependency with more runtime arguments than
+             _Dip_ supports (currently it's up to six) like in the following example:
+     
+     ```swift
+     public func resolve<T, A, B, C, ...>(tag: Tag? = nil, _ arg1: A, _ arg2: B, _ arg3: C, ...) throws -> T {
+       return try resolve(tag: tag) { factory in factory(arg1, arg2, arg3, ...) }
+     }
+     ```
+     
+     Though before you do so you should probably review your design and try to reduce the number of dependencies.
+     */
+    public func resolve<T, U>(tag tag: DependencyTagConvertible? = nil, builder: ((U) throws -> T) throws -> T) throws -> T {
+      return try _resolve(tag: tag, builder: builder)
+    }
+    
+    /**
+     Resolve an instance of provided type using builder closure. Weakly-typed alternative of `resolve(tag:builder:)`
+     
+     - seealso: `resolve(tag:builder:)`
+     */
+    public func resolve<U>(type: Any.Type, tag: DependencyTagConvertible? = nil, builder: ((U) throws -> Any) throws -> Any) throws -> Any {
+      return try _resolve(type: type, tag: tag, builder: builder)
+    }
+  
+  }
+  
+  /// Resolvable protocol provides some extension points for resolving dependencies with property injection.
+  public protocol Resolvable {
+    /// This method will be called right after instance is created by the container.
+    func resolveDependencies(container: DependencyContainer)
+    /// This method will be called when all dependencies of the instance are resolved.
+    /// When resolving objects graph the last resolved instance will receive this callback first.
+    func didResolveDependencies()
+  }
+
+  extension Resolvable {
+    func resolveDependencies(container: DependencyContainer) {}
+    func didResolveDependencies() {}
+  }
+
+#endif
+
+

--- a/Sources/RuntimeArguments_swift2.swift
+++ b/Sources/RuntimeArguments_swift2.swift
@@ -22,8 +22,8 @@
 // THE SOFTWARE.
 //
 
-#if swift(>=3.0)
-  
+#if !swift(>=3.0)
+
   extension DependencyContainer {
     
     /**
@@ -67,7 +67,7 @@
      container.register(Client.self, factory: ClientImp.init(service:))
      ```
      */
-    @discardableResult public func register<T>(_ scope: ComponentScope = .shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: @escaping () throws -> T) -> Definition<T, ()> {
+    public func register<T>(scope: ComponentScope = .Shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: () throws -> T) -> Definition<T, ()> {
       let definition = DefinitionBuilder<T, ()> {
         $0.scope = scope
         $0.factory = factory
@@ -94,15 +94,15 @@
      
      ```swift
      public func register<T, A, B, C, ...>(_ scope: ComponentScope = .shared, type: T.Type = T.self, tag: Tag? = nil, factory: (A, B, C, ...) throws -> T) -> Definition<T, (A, B, C, ...)> {
-       return register(scope: scope, type: type, tag: tag, factory: factory, numberOfArguments: ...) { container, tag in
-         try factory(container.resolve(tag: tag), ...)
-       }
+        return register(scope: scope, type: type, tag: tag, factory: factory, numberOfArguments: ...) { container, tag in
+          try factory(container.resolve(tag: tag), ...)
+        }
      }
      ```
      
      Though before you do so you should probably review your design and try to reduce number of depnedencies.
      */
-    public func register<T, U>(scope: ComponentScope, type: T.Type, tag: DependencyTagConvertible?, factory: @escaping (U) throws -> T, numberOfArguments: Int, autoWiringFactory: @escaping (DependencyContainer, Tag?) throws -> T) -> Definition<T, U> {
+    public func register<T, U>(scope: ComponentScope, type: T.Type, tag: DependencyTagConvertible?, factory: (U) throws -> T, numberOfArguments: Int, autoWiringFactory: (DependencyContainer, Tag?) throws -> T) -> Definition<T, U> {
       let definition = DefinitionBuilder<T, U> {
         $0.scope = scope
         $0.factory = factory
@@ -116,29 +116,29 @@
     // MARK: 1 Runtime Argument
     
     /**
-    Register factory that accepts one runtime argument of type `A`. You can use up to six runtime arguments.
-
-    - note: You can have several factories with different number or types of arguments registered for same type,
-            optionally associated with some tags. When container resolves that type it matches the type,
-            __number__, __types__ and __order__ of runtime arguments and optional tag that you pass to `resolve(tag:arguments:)` method.
-
-    - parameters:
-      - tag: The arbitrary tag to associate this factory with. Pass `nil` to associate with any tag. Default value is `nil`.
-      - scope: The scope to use for this component. Default value is `Shared`.
-      - factory: The factory to register.
-    
-    - seealso: `register(_:type:tag:factory:)`
-    */
-    @discardableResult public func register<T, A>(_ scope: ComponentScope = .shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: @escaping (A) throws -> T) -> Definition<T, A> {
-      return register(scope: scope, type: type, tag: tag, factory: factory, numberOfArguments: 1) { container, tag in try factory(container.resolve(tag: tag)) }
+     Register factory that accepts one runtime argument of type `A`. You can use up to six runtime arguments.
+     
+     - note: You can have several factories with different number or types of arguments registered for same type,
+             optionally associated with some tags. When container resolves that type it matches the type,
+             __number__, __types__ and __order__ of runtime arguments and optional tag that you pass to `resolve(tag:arguments:)` method.
+     
+     - parameters:
+        - tag: The arbitrary tag to associate this factory with. Pass `nil` to associate with any tag. Default value is `nil`.
+        - scope: The scope to use for this component. Default value is `Shared`.
+        - factory: The factory to register.
+     
+     - seealso: `register(_:type:tag:factory:)`
+     */
+    public func register<T, A>(scope: ComponentScope = .Shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: (A) throws -> T) -> Definition<T, A> {
+      return register(scope, type: type, tag: tag, factory: factory, numberOfArguments: 1) { container, tag in try factory(container.resolve(tag: tag)) }
     }
-
+    
     /**
      Resolve type `T` using one runtime argument.
      
-     - note: When resolving a type container will first try to use definition 
-             that exactly matches types of arguments that you pass to resolve method. 
-             If it fails or no such definition is found container will try to _auto-wire_ component. 
+     - note: When resolving a type container will first try to use definition
+             that exactly matches types of arguments that you pass to resolve method.
+             If it fails or no such definition is found container will try to _auto-wire_ component.
              For that it will iterate through all the definitions registered for that type
              which factories accept any number of runtime arguments and are tagged with the same tag,
              passed to `resolve` method, or with no tag. Container will try to use these definitions
@@ -152,105 +152,105 @@
         - arg1: The first argument to pass to the definition's factory.
      
      - throws: `DipError.DefinitionNotFound`, `DipError.AutoInjectionFailed`, `DipError.AmbiguousDefinitions`
-
+     
      - returns: An instance of type `T`.
-
-     - seealso: `register(_:type:tag:factory:)`, `resolve(tag:builder:)`
+     
+     - seealso: `register(_:tag:factory:)`, `resolve(tag:builder:)`
      */
     public func resolve<T, A>(tag: DependencyTagConvertible? = nil, arguments arg1: A) throws -> T {
       return try resolve(tag: tag) { factory in try factory(arg1) }
     }
-
+    
     ///- seealso: `resolve(_:tag:)`, `resolve(tag:arguments:)`
-    public func resolve<A>(_ type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A) throws -> Any {
+    public func resolve<A>(type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A) throws -> Any {
       return try resolve(type, tag: tag) { factory in try factory(arg1) }
     }
-
+    
     // MARK: 2 Runtime Arguments
     
     /// - seealso: `register(_:type:tag:factory:)`
-    @discardableResult public func register<T, A, B>(_ scope: ComponentScope = .shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: @escaping (A, B) throws -> T) -> Definition<T, (A, B)> {
-      return register(scope: scope, type: type, tag: tag, factory: factory, numberOfArguments: 2) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag)) }
+    public func register<T, A, B>(scope: ComponentScope = .Shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: (A, B) throws -> T) -> Definition<T, (A, B)> {
+      return register(scope, type: type, tag: tag, factory: factory, numberOfArguments: 2) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag)) }
     }
-
+    
     /// - seealso: `resolve(tag:arguments:)`
     public func resolve<T, A, B>(tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B) throws -> T {
       return try resolve(tag: tag) { factory in try factory(arg1, arg2) }
     }
     
     ///- seealso: `resolve(_:tag:)`, `resolve(tag:arguments:)`
-    public func resolve<A, B>(_ type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B) throws -> Any {
+    public func resolve<A, B>(type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B) throws -> Any {
       return try resolve(type, tag: tag) { factory in try factory((arg1, arg2)) }
     }
     
     // MARK: 3 Runtime Arguments
     
     /// - seealso: `register(_:type:tag:factory:)`
-    @discardableResult public func register<T, A, B, C>(_ scope: ComponentScope = .shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: @escaping (A, B, C) throws -> T) -> Definition<T, (A, B, C)> {
-      return register(scope: scope, type: type, tag: tag, factory: factory, numberOfArguments: 3)  { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
+    public func register<T, A, B, C>(scope: ComponentScope = .Shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: (A, B, C) throws -> T) -> Definition<T, (A, B, C)> {
+      return register(scope, type: type, tag: tag, factory: factory, numberOfArguments: 3)  { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
     }
-
+    
     /// - seealso: `resolve(tag:arguments:)`
     public func resolve<T, A, B, C>(tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C) throws -> T {
       return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3) }
     }
     
     ///- seealso: `resolve(_:tag:)`, `resolve(tag:arguments:)`
-    public func resolve<A, B, C>(_ type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C) throws -> Any {
+    public func resolve<A, B, C>(type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C) throws -> Any {
       return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3)) }
     }
-
+    
     // MARK: 4 Runtime Arguments
     
     /// - seealso: `register(_:type:tag:factory:)`
-    @discardableResult public func register<T, A, B, C, D>(_ scope: ComponentScope = .shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: @escaping (A, B, C, D) throws -> T) -> Definition<T, (A, B, C, D)> {
-      return register(scope: scope, type: type, tag: tag, factory: factory, numberOfArguments: 4) { container, tag in try factory(container.resolve(tag: tag),  container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
+    public func register<T, A, B, C, D>(scope: ComponentScope = .Shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: (A, B, C, D) throws -> T) -> Definition<T, (A, B, C, D)> {
+      return register(scope, type: type, tag: tag, factory: factory, numberOfArguments: 4) { container, tag in try factory(container.resolve(tag: tag),  container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
     }
-
+    
     /// - seealso: `resolve(tag:arguments:)`
     public func resolve<T, A, B, C, D>(tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D) throws -> T {
       return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3, arg4) }
     }
-
+    
     /// - seealso: `resolve(_:tag:)`, `resolve(tag:arguments:)`
-    public func resolve<A, B, C, D>(_ type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D) throws -> Any {
+    public func resolve<A, B, C, D>(type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D) throws -> Any {
       return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3, arg4)) }
     }
-
+    
     // MARK: 5 Runtime Arguments
     
     /// - seealso: `register(_:type:tag:factory:)`
-    @discardableResult public func register<T, A, B, C, D, E>(_ scope: ComponentScope = .shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: @escaping (A, B, C, D, E) throws -> T) -> Definition<T, (A, B, C, D, E)> {
-      return register(scope: scope, type: type, tag: tag, factory: factory, numberOfArguments: 5) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
+    public func register<T, A, B, C, D, E>(scope: ComponentScope = .Shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: (A, B, C, D, E) throws -> T) -> Definition<T, (A, B, C, D, E)> {
+      return register(scope, type: type, tag: tag, factory: factory, numberOfArguments: 5) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
     }
-
+    
     /// - seealso: `resolve(tag:arguments:)`
     public func resolve<T, A, B, C, D, E>(tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E) throws -> T {
       return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3, arg4, arg5) }
     }
-
+    
     ///- seealso: `resolve(_:tag:)`, `resolve(tag:arguments:)`
-    public func resolve<A, B, C, D, E>(_ type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E) throws -> Any {
+    public func resolve<A, B, C, D, E>(type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E) throws -> Any {
       return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3, arg4, arg5)) }
     }
-
+    
     // MARK: 6 Runtime Arguments
     
     /// - seealso: `register(_:type:tag:factory:)`
-    @discardableResult public func register<T, A, B, C, D, E, F>(_ scope: ComponentScope = .shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: @escaping (A, B, C, D, E, F) throws -> T) -> Definition<T, (A, B, C, D, E, F)> {
-      return register(scope: scope, type: type, tag: tag, factory: factory, numberOfArguments: 6) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
+    public func register<T, A, B, C, D, E, F>(scope: ComponentScope = .Shared, type: T.Type = T.self, tag: DependencyTagConvertible? = nil, factory: (A, B, C, D, E, F) throws -> T) -> Definition<T, (A, B, C, D, E, F)> {
+      return register(scope, type: type, tag: tag, factory: factory, numberOfArguments: 6) { container, tag in try factory(container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag), container.resolve(tag: tag)) }
     }
-
+    
     /// - seealso: `resolve(tag:arguments:)`
     public func resolve<T, A, B, C, D, E, F>(tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E, _ arg6: F) throws -> T {
       return try resolve(tag: tag) { factory in try factory(arg1, arg2, arg3, arg4, arg5, arg6) }
     }
-
+    
     /// - seealso: `resolve(_:tag:)`, `resolve(tag:arguments:)`
-    public func resolve<A, B, C, D, E, F>(_ type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E, _ arg6: F) throws -> Any {
+    public func resolve<A, B, C, D, E, F>(type: Any.Type, tag: DependencyTagConvertible? = nil, arguments arg1: A, _ arg2: B, _ arg3: C, _ arg4: D, _ arg5: E, _ arg6: F) throws -> Any {
       return try resolve(type, tag: tag) { factory in try factory((arg1, arg2, arg3, arg4, arg5, arg6)) }
     }
-
+    
   }
-  
+
 #endif

--- a/Sources/TypeForwarding_swift2.swift
+++ b/Sources/TypeForwarding_swift2.swift
@@ -1,0 +1,88 @@
+//
+// Dip
+//
+// Copyright (c) 2015 Olivier Halligon <olivier@halligon.net>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#if !swift(>=3.0)
+
+extension Definition {
+  
+  /**
+   Registers definition for passed type.
+   
+   If instance created by factory of definition on which method is called
+   does not implement type passed in a `type` parameter,
+   container will throw `DipError.DefinitionNotFound` error when trying to resolve that type.
+   
+   - parameters:
+   - type: Type to register definition for
+   - tag: Optional tag to associate definition with. Default is `nil`.
+   
+   - returns: definition on which `implements` was called
+   */
+  public func implements<F>(type: F.Type, tag: DependencyTagConvertible? = nil) -> Definition {
+    precondition(container != nil, "Definition should be registered in the container.")
+    
+    container!.register(self, type: type, tag: tag)
+    return self
+  }
+  
+  /**
+   Registers definition for passed type.
+   
+   If instance created by factory of definition on which method is called
+   does not implement type passed in a `type` parameter,
+   container will throw `DipError.DefinitionNotFound` error when trying to resolve that type.
+   
+   - parameters:
+      - type: Type to register definition for
+      - tag: Optional tag to associate definition with. Default is `nil`.
+      - resolvingProperties: Optional block to be called to resolve instance property dependencies
+   
+   - returns: definition on which `implements` was called
+   */
+  public func implements<F>(type: F.Type, tag: DependencyTagConvertible? = nil, resolvingProperties: (DependencyContainer, F) throws -> ()) -> Definition {
+    precondition(container != nil, "Definition should be registered in the container.")
+    
+    let forwardDefinition = container!.register(self, type: type, tag: tag)
+    forwardDefinition.resolvingProperties(resolvingProperties)
+    return self
+  }
+  
+  ///Registers definition for types passed as parameters
+  public func implements<A, B>(a: A.Type, _ b: B.Type) -> Definition {
+    return implements(a).implements(b)
+  }
+  
+  ///Registers definition for types passed as parameters
+  public func implements<A, B, C>(a: A.Type, _ b: B.Type, _ c: C.Type) -> Definition {
+    return implements(a).implements(b).implements(c)
+  }
+  
+  ///Registers definition for types passed as parameters
+  public func implements<A, B, C, D>(a: A.Type, _ b: B.Type, c: C.Type, d: D.Type) -> Definition {
+    return implements(a).implements(b).implements(c).implements(d)
+  }
+
+}
+
+#endif

--- a/Tests/DipTests/AutoInjectionTests.swift
+++ b/Tests/DipTests/AutoInjectionTests.swift
@@ -31,7 +31,7 @@ private protocol Server: class {
 }
 
 private protocol Client: class {
-  var server: Server! {get}
+  var server: Server? {get}
   var anotherServer: Server! {get set}
 }
 
@@ -56,7 +56,7 @@ private class ClientImp: Client {
     AutoInjectionTests.serverDidInjectCalled = true
   }
 
-  var server: Server! {
+  var server: Server? {
     return _server.value
   }
 


### PR DESCRIPTION
This PR brings support for both Swift 2.3 and Swift 3 so that there is no need to keep a separate brunch for Swift 2.3 and it will be easier to drop it's support as part of 2.3 specific implementation is moved to separate source files.

- [x] check installing with Cocoapods and Carthage