### PR TITLE
Fixed reusing instances for weak singletons

### DIFF
--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -723,7 +723,9 @@ private class ResolvedInstances {
     get {
       switch scope {
       case .singleton, .eagerSingleton: return singletons[key]
-      case .weakSingleton: return (weakSingletons[key] as? WeakBoxType)?.unboxed ?? weakSingletons[key]
+      case .weakSingleton:
+        if let boxed = weakSingletons[key] as? WeakBoxType { return boxed.unboxed }
+        else { return weakSingletons[key] }
       case .shared: return resolvedInstances[key]
       case .unique: return nil
       }

--- a/Tests/DipTests/ComponentScopeTests.swift
+++ b/Tests/DipTests/ComponentScopeTests.swift
@@ -62,8 +62,9 @@ class ComponentScopeTests: XCTestCase {
       ("testThatItDoesNotReuseInstanceInSharedScopeResolvedForNilTag", testThatItDoesNotReuseInstanceInSharedScopeResolvedForNilTagWhenResolvingForAnotherTag),
       ("testThatItReusesInstanceInSharedScopeResolvedForNilTag", testThatItReusesInstanceInSharedScopeResolvedForNilTag),
       ("testThatItReusesResolvedInstanceWhenResolvingOptional", testThatItReusesResolvedInstanceWhenResolvingOptional),
-      ("testThatItHoldsWeakReferenceToWeakSingletonInstance",
-          testThatItHoldsWeakReferenceToWeakSingletonInstance)
+      ("testThatItHoldsWeakReferenceToWeakSingletonInstance", testThatItHoldsWeakReferenceToWeakSingletonInstance),
+      ("testThatItResolvesWeakSingletonAgainAfterItWasReleased", testThatItResolvesWeakSingletonAgainAfterItWasReleased),
+      ("testThatCollaboratingContainersReuseSingletonsResolvedByAnotherContainer", testThatCollaboratingContainersReuseSingletonsResolvedByAnotherContainer)
     ]
   }()
   
@@ -333,6 +334,20 @@ class ComponentScopeTests: XCTestCase {
     
     //then
     XCTAssertNil(weakSingleton)
+  }
+  
+  func testThatItResolvesWeakSingletonAgainAfterItWasReleased() {
+    Dip.logLevel = .Verbose
+    //given
+    let service = container.register(.weakSingleton) { ServiceImp1() }
+    container.register(service, type: Service.self)
+    
+    //when
+    //resolve and realease reight away
+    _ = try? container.resolve() as ServiceImp1
+    
+    //then
+    AssertNoThrow(expression: try container.resolve() as Service, "Weak singleton should be resolved again.")
   }
   
   func testThatCollaboratingContainersReuseSingletonsResolvedByAnotherContainer() {


### PR DESCRIPTION
when underlying instance was already released

Resolves #128 