### PR TITLE
Fix swift 3.1 warning

### DIFF
--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -35,7 +35,7 @@ public struct DefinitionKey : Hashable, CustomStringConvertible {
   }
   
   public var hashValue: Int {
-    return "\(type)-\(typeOfArguments)-\(tag)".hashValue
+    return "\(type)-\(typeOfArguments)-\(tag ?? "")".hashValue
   }
   
   public var description: String {


### PR DESCRIPTION
This change is backwards-compatible fix for new warning in Xcode 8.3/ Swift 3.1 mentioned in #144 