### PR TITLE
Enable use of custom or no logging function

### DIFF
--- a/Sources/Utils.swift
+++ b/Sources/Utils.swift
@@ -30,9 +30,15 @@ public enum LogLevel: Int {
 
 public var logLevel: LogLevel = .Errors
 
+public typealias LoggingFunctionType = (LogLevel, Any) -> Void
+
+public var loggingFunction: LoggingFunctionType? = { _, message in
+  print(message)
+}
+
 func log(level logLevel: LogLevel, _ message: Any) {
   guard logLevel.rawValue <= Dip.logLevel.rawValue else { return }
-  print(message)
+  loggingFunction?(logLevel, message)
 }
 
 ///Internal protocol used to unwrap optional values.


### PR DESCRIPTION
This is a copy of Swinject feature: https://github.com/Swinject/Swinject/blob/master/Sources/Container.Logging.swift

It will allow user to redirect Dip logs to file and/or some custom logger if it's required