### PR TITLE
Autowiring should prioritize the definition with the matching tag

### DIFF
--- a/Sources/AutoWiring.swift
+++ b/Sources/AutoWiring.swift
@@ -62,9 +62,15 @@ extension DependencyContainer {
     let maximumNumberOfArguments = definitions.first?.definition.numberOfArguments
     definitions = definitions.filter({ $0.definition.numberOfArguments == maximumNumberOfArguments })
     definitions = order(definitions: definitions, byTag: key.tag)
-
-    //when there are several definitions with the same number of arguments but different arguments types
-    if definitions.count > 1 && definitions[0].key.typeOfArguments != definitions[1].key.typeOfArguments {
+    
+    let firstDefinitionHasAMatchingTag = (key.tag == definitions[0].key.tag)
+    let secondDefinitionHasADifferentTag = definitions.count > 1 && (key.tag != definitions[1].key.tag)
+    
+      //when there are several definitions but only one matches the tag
+    if firstDefinitionHasAMatchingTag && secondDefinitionHasADifferentTag{
+      return definitions[0]
+    }else if definitions.count > 1 && definitions[0].key.typeOfArguments != definitions[1].key.typeOfArguments {
+      //when there are several definitions with the same number of arguments but different arguments types
       let error = DipError.ambiguousDefinitions(type: key.type, definitions: definitions.map({ $0.definition }))
       throw DipError.autoWiringFailed(type: key.type, underlyingError: error)
     } else {

--- a/Tests/DipTests/AutoWiringTests.swift
+++ b/Tests/DipTests/AutoWiringTests.swift
@@ -53,6 +53,7 @@ class AutoWiringTests: XCTestCase {
   static var allTests = {
     return [
       ("testThatItCanResolveWithAutoWiring", testThatItCanResolveWithAutoWiring),
+      ("testThatItPrioritizesDefinitionWithTheMatchingTag", testThatItPrioritizesDefinitionWithTheMatchingTag),
       ("testThatItUsesAutoWireFactoryWithMostNumberOfArguments", testThatItUsesAutoWireFactoryWithMostNumberOfArguments),
       ("testThatItThrowsAmbiguityErrorWhenUsingAutoWire", testThatItThrowsAmbiguityErrorWhenUsingAutoWire),
       ("testThatItFirstTriesToUseTaggedFactoriesWhenUsingAutoWire", testThatItFirstTriesToUseTaggedFactoriesWhenUsingAutoWire),
@@ -97,6 +98,23 @@ class AutoWiringTests: XCTestCase {
     
     //then
     XCTAssertTrue(anyClient is AutoWiredClientImp)
+  }
+  
+  func testThatItPrioritizesDefinitionWithTheMatchingTag(){
+    //given
+    let tag = "tag"
+    
+    container.register { AutoWiredClientImp(service1: $1, service2: $0) as AutoWiredClient }
+    container.register (tag: tag, factory: { AutoWiredClientImp(service1: $0, service2: $1) as AutoWiredClient })
+
+    container.register { ServiceImp1() as Service }
+    container.register { ServiceImp2() }
+    
+    var resolved: AutoWiredClient?
+    
+    //when
+    AssertNoThrow(expression: resolved = try container.resolve(tag: tag) as AutoWiredClient)
+    XCTAssertNotNil(resolved)
   }
   
   func testThatItUsesAutoWireFactoryWithMostNumberOfArguments() {


### PR DESCRIPTION
Problem:

```
// Add interactor
container.register(.shared) { (entryDataAdapter: EntryDataAdapter, dateFormatter: DateFormatter) -> AbstractAddEntryInteractor in
   return AddEntryInteractor(entryDataAdapter: entryDataAdapter, dateFormatter: dateFormatter)
}.resolvingProperties({ (container, interactor) in
   interactor.presenter = try! container.resolve(tag: container.context.tag)
})

// Same module, different interactor; tag "editEntry"
container.register(tag: "editEntry", factory: { (selectedEntryID: Int, entryDataAdapter: EntryDataAdapter) -> AbstractAddEntryInteractor in
    return EditEntryInteractor(selectedEntryID: selectedEntryID, dataAdapter: entryDataAdapter) as AbstractAddEntryInteractor
}).resolvingProperties({ (container, interactor) in
   interactor.presenter = try! container.resolve(tag: container.context.tag)
})

// this is where interactor gets resolved
container.register(.shared) { () -> AbstractAddEntryPresenter in
   return AddEntryPresenter()
}.resolvingProperties({ (container, presenter) in
   presenter.interactor = try! container.resolve(tag: container.context.tag)
   presenter.view = try! container.resolve(tag: container.context.tag)
   presenter.routing = try! container.resolve(tag: container.context.tag)
})
```

Autowiring fails with DipError.ambiguousDefinitions while resolving graph with "editEntry" tag because there are multiple definitions with different arguments, specifically this line

```
// AutoWiring.swift, line 67
if definitions.count > 1 && definitions[0].key.typeOfArguments != definitions[1].key.typeOfArguments
``` 

even though only one definition matches the tag, so the instance should correctly get resolved.