### PR TITLE
Added Equatable conformance on the site of declaration

### DIFF
--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -23,7 +23,7 @@
 //
 
 ///A key used to store definitons in a container.
-public struct DefinitionKey : Hashable, CustomStringConvertible {
+public struct DefinitionKey: Hashable, CustomStringConvertible {
   public let type: Any.Type
   public let typeOfArguments: Any.Type
   public private(set) var tag: DependencyContainer.Tag?
@@ -47,15 +47,15 @@ public struct DefinitionKey : Hashable, CustomStringConvertible {
     tagged.tag = tag
     return tagged
   }
-  
-}
 
-/// Check two definition keys on equality by comparing their `type`, `factoryType` and `tag` properties.
-public func ==(lhs: DefinitionKey, rhs: DefinitionKey) -> Bool {
-  return
-    lhs.type == rhs.type &&
+  /// Check two definition keys on equality by comparing their `type`, `factoryType` and `tag` properties.
+  public static func ==(lhs: DefinitionKey, rhs: DefinitionKey) -> Bool {
+    return
+      lhs.type == rhs.type &&
       lhs.typeOfArguments == rhs.typeOfArguments &&
       lhs.tag == rhs.tag
+  }
+  
 }
 
 ///Dummy protocol to store definitions for different types in collection

--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -34,7 +34,7 @@ public final class DependencyContainer {
    
    - seealso: `DependencyTagConvertible`
    */
-  public enum Tag: Equatable {
+  public enum Tag {
     case String(StringLiteralType)
     case Int(IntegerLiteralType)
   }
@@ -477,13 +477,17 @@ extension DependencyContainer.Tag: ExpressibleByIntegerLiteral {
   
 }
 
-public func ==(lhs: DependencyContainer.Tag, rhs: DependencyContainer.Tag) -> Bool {
-  switch (lhs, rhs) {
-  case let (.String(lhsString), .String(rhsString)):
-    return lhsString == rhsString
-  case let (.Int(lhsInt), .Int(rhsInt)):
-    return lhsInt == rhsInt
-  default:
-    return false
+extension DependencyContainer.Tag: Equatable {
+
+  public static func ==(lhs: DependencyContainer.Tag, rhs: DependencyContainer.Tag) -> Bool {
+    switch (lhs, rhs) {
+    case let (.String(lhsString), .String(rhsString)):
+      return lhsString == rhsString
+    case let (.Int(lhsInt), .Int(rhsInt)):
+      return lhsInt == rhsInt
+    default:
+      return false
+    }
   }
+
 }


### PR DESCRIPTION
## Things done
- [x] Equatable conformance method can now be used as static function inside the type. In this Pull Request, I am moving the conformance into the site of declaration and fixing typos as i try to understand the codebase. 

