### PR TITLE
Fix crash with colaborator containers and weak singletons

### DIFF
--- a/Sources/Dip.swift
+++ b/Sources/Dip.swift
@@ -313,13 +313,13 @@ extension DependencyContainer {
           for (key, resolvedSingleton) in self.resolvedInstances.singletons {
             collaborator.resolvedInstances.singletons[key] = resolvedSingleton
           }
-          for (_, resolvedSingleton) in self.resolvedInstances.weakSingletons {
-            guard collaborator.definition(matching: aKey) != nil else { continue }
-            collaborator.resolvedInstances.weakSingletons[aKey] = WeakBox(resolvedSingleton)
+          for (key, resolvedSingleton) in self.resolvedInstances.weakSingletons {
+            guard collaborator.definition(matching: key) == nil else { continue }
+            collaborator.resolvedInstances.weakSingletons[key] = resolvedSingleton is WeakBoxType ? resolvedSingleton :  WeakBox(resolvedSingleton)
           }
-          for (_, resolved) in self.resolvedInstances.resolvedInstances {
-            guard collaborator.definition(matching: aKey) != nil else { continue }
-            collaborator.resolvedInstances.resolvedInstances[aKey] = resolved
+          for (key, resolved) in self.resolvedInstances.resolvedInstances {
+            guard collaborator.definition(matching: key) == nil else { continue }
+            collaborator.resolvedInstances.resolvedInstances[key] = resolved
           }
         }
 


### PR DESCRIPTION
I have an issue with a configuration using a main container created at startup with many factories and bootstrapped and a secondary container that it's dynamically configured during the app lifetime. I sometimes get a crash when resolving weak singletons. The crash points that it can't cast the resolved instance to the required type. This indicates that the resolved instances caches are corrupted at some point.

This same container setup works perfectly with version 5.1 of Dip but I need swift 4 for the next version of the app.

Signed-off-by: Antonio Cabezuelo Vivo <antonio@tapsandswipes.com>