### PR TITLE
Removed extension of ImplicitlyUnwrappedOptional

### DIFF
--- a/Sources/Utils.swift
+++ b/Sources/Utils.swift
@@ -48,12 +48,6 @@ extension Optional: BoxType {
   }
 }
 
-extension ImplicitlyUnwrappedOptional: BoxType {
-  var unboxed: Any? {
-    return self ?? nil
-  }
-}
-
 class Box<T> {
   var unboxed: T
   init(_ value: T) {

--- a/Sources/Utils.swift
+++ b/Sources/Utils.swift
@@ -48,6 +48,15 @@ extension Optional: BoxType {
   }
 }
 
+#if swift(>=4.1)
+#else
+extension ImplicitlyUnwrappedOptional: BoxType {
+  var unboxed: Any? {
+    return self ?? nil
+  }
+}
+#endif
+
 class Box<T> {
   var unboxed: T
   init(_ value: T) {


### PR DESCRIPTION
ImplicitlyUnwrappedOptional was already deprecated and it has been removed in swift 4.2
If you don't remove this extension Dip won't compile with Swift 4.2