### PR TITLE
Adjust Dip scheme to remove code coverage for Carthage Static Frameworks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ matrix:
     - os: linux
   include:
     - script:
-        - set -o pipefail && xcodebuild test -workspace Dip.xcworkspace -scheme Dip -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest' ONLY_ACTIVE_ARCH=NO | xcpretty -c
-        - set -o pipefail && xcodebuild test -workspace Dip.xcworkspace -scheme Dip -sdk macosx -destination 'platform=macOS,arch=x86_64' ONLY_ACTIVE_ARCH=NO | xcpretty -c
+        - set -o pipefail && xcodebuild test -workspace Dip.xcworkspace -scheme "Dip Tests" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest' ONLY_ACTIVE_ARCH=NO | xcpretty -c
+        - set -o pipefail && xcodebuild test -workspace Dip.xcworkspace -scheme "Dip Tests" -sdk macosx -destination 'platform=macOS,arch=x86_64' ONLY_ACTIVE_ARCH=NO | xcpretty -c
         - pod spec lint --allow-warnings
         - carthage build --no-skip-current
       os: osx

--- a/Dip/Dip.xcodeproj/xcshareddata/xcschemes/Dip Tests.xcscheme
+++ b/Dip/Dip.xcodeproj/xcshareddata/xcschemes/Dip Tests.xcscheme
@@ -1,25 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0903B3571C161543002241C1"
-               BuildableName = "Dip.framework"
-               BlueprintName = "Dip"
-               ReferencedContainer = "container:Dip.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "NO"
@@ -28,9 +14,9 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0903B3601C161543002241C1"
-               BuildableName = "DipTests.xctest"
-               BlueprintName = "DipTests"
+               BlueprintIdentifier = "0903B3571C161543002241C1"
+               BuildableName = "Dip.framework"
+               BlueprintName = "Dip"
                ReferencedContainer = "container:Dip.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -41,7 +27,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -77,15 +64,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "0903B3571C161543002241C1"
-            BuildableName = "Dip.framework"
-            BlueprintName = "Dip"
-            ReferencedContainer = "container:Dip.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -95,15 +73,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "0903B3571C161543002241C1"
-            BuildableName = "Dip.framework"
-            BlueprintName = "Dip"
-            ReferencedContainer = "container:Dip.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
... and add a new Testing scheme that has code coverage.

We're currently using Carthage static frameworks (https://github.com/Carthage/Carthage/blob/master/Documentation/StaticFrameworks.md) in our applications to increase app load times.

However, when Carthage builds Dip for static frameworks, the code coverage option on the Dip scheme leads to the following errors:

```
Undefined symbols for architecture x86_64:
  "___llvm_profile_runtime", referenced from:
```

By disabling code coverage on the scheme that Carthage builds, this issue is resolved.

I've added a separate Scheme solely for tests that enables code coverage, and adjusted the .travis.yml settings to use that.
