### PR TITLE
Disable gathering code coverage

### DIFF
--- a/Dip/Dip.xcodeproj/xcshareddata/xcschemes/Dip.xcscheme
+++ b/Dip/Dip.xcodeproj/xcshareddata/xcschemes/Dip.xcscheme
@@ -40,7 +40,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference


### PR DESCRIPTION
This causes issues whenn linking as a static library using Carthage:

```
Undefined symbols for architecture x86_64:
  "___llvm_profile_runtime", referenced from:
      ___llvm_profile_runtime_user in Dip(Utils.o)
      ___llvm_profile_runtime_user in Dip(Definition.o)
      ___llvm_profile_runtime_user in Dip(ComponentScope.o)
      ___llvm_profile_runtime_user in Dip(AutoWiring.o)
      ___llvm_profile_runtime_user in Dip(Dip.o)
      ___llvm_profile_runtime_user in Dip(Register.o)
      ___llvm_profile_runtime_user in Dip(Resolve.o)
```