### PR TITLE
Fix for Swift 4.2 changes in Optional<->Any conversions

### DIFF
--- a/Sources/Resolve.swift
+++ b/Sources/Resolve.swift
@@ -199,7 +199,7 @@ extension DependencyContainer {
      That happens because when Optional is casted to Any Swift can not implicitly unwrap it with as operator.
      As a workaround we detect boxing here and unwrap it so that we return not a box, but wrapped instance.
      */
-    if let box = resolvedInstance as? BoxType, let unboxed = box.unboxed as? T {
+    if let box = resolvedInstance as? BoxType, let unboxedAny = box.unboxed, let unboxed = unboxedAny as? T {
       resolvedInstance = unboxed
     }
     


### PR DESCRIPTION
In Xcode 10 beta 5, the unboxing of optional values started to fail, because the code simultaneously tried to test for an empty optional and a successful cast. Breaking this up in two steps fixes the issue.