### PR TITLE
Fix SPM compatibility with swift-tools-version:4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
 //
 // Dip
 //
@@ -25,6 +27,12 @@
 import PackageDescription
 
 let package = Package(
-    name: "Dip"
+    name: "Dip",
+	products: [
+		.library(name: "Dip", targets: ["Dip"])
+	],
+	targets: [
+		.target(name: "Dip", dependencies: [], path: "./Sources"),
+	]
 )
 


### PR DESCRIPTION
This Pull Request fix the issue with Swift Package Manager 4.0 and above.
It is now possible to install DIP with SPM.