### PR TITLE
Bump watchos deployment target to 3.0

### DIFF
--- a/Dip/Dip.xcodeproj/project.pbxproj
+++ b/Dip/Dip.xcodeproj/project.pbxproj
@@ -484,7 +484,7 @@
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Debug;
 		};
@@ -542,7 +542,7 @@
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Apple now requires that watchOS deployment target are minimum locked at 3.0 version.

https://forums.developer.apple.com/thread/108853

Could you create a tag after merging so we can use it on Carthage?

Thank you!