### PR TITLE
Use preferred AnyObject keyword

### DIFF
--- a/DipPlayground.playground/Pages/Auto-injection.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Auto-injection.xcplaygroundpage/Contents.swift
@@ -13,7 +13,7 @@ On the previous page you saw how auto-wiring helps us to get rid of boilerplate 
 Let's say you have following related components:
 */
 
-protocol Service: class {
+protocol Service: AnyObject {
     var logger: Logger? { get }
     var tracker: Tracker? { get }
 }
@@ -101,11 +101,11 @@ serverWithNoClient.optionalClient.value
 Another example of using auto-injection is circular dependencies. Let's say you have a `Server` and a `ServerClient` both referencing each other.
 */
 
-protocol Server: class {
+protocol Server: AnyObject {
     weak var client: ServerClient? { get }
 }
 
-protocol ServerClient: class {
+protocol ServerClient: AnyObject {
     var server: Server? { get }
 }
 

--- a/DipPlayground.playground/Pages/Circular dependencies.xcplaygroundpage/Contents.swift
+++ b/DipPlayground.playground/Pages/Circular dependencies.xcplaygroundpage/Contents.swift
@@ -13,11 +13,11 @@ Very often we encounter situations when we have circular dependencies between co
 Let's say you have some network client and it's delegate defined like this:
 */
 
-protocol NetworkClientDelegate: class {
+protocol NetworkClientDelegate: AnyObject {
     var networkClient: NetworkClient { get }
 }
 
-protocol NetworkClient: class {
+protocol NetworkClient: AnyObject {
     weak var delegate: NetworkClientDelegate? { get set }
 }
 

--- a/DipPlayground.playground/Sources/Models.swift
+++ b/DipPlayground.playground/Sources/Models.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol Service: class {}
+public protocol Service: AnyObject {}
 
 public class ServiceImp1: Service {
   public init() {}
@@ -22,7 +22,7 @@ public class ServiceImp4: Service {
   
 }
 
-public protocol Client: class {
+public protocol Client: AnyObject {
   var service: Service {get}
   init(service: Service)
 }
@@ -74,9 +74,9 @@ public class DataProviderImp: DataProvider {
     public init() {}
 }
 
-public protocol ListInteractorOutput: class {}
-public protocol ListModuleInterface: class {}
-public protocol ListInteractorInput: class {}
+public protocol ListInteractorOutput: AnyObject {}
+public protocol ListModuleInterface: AnyObject {}
+public protocol ListInteractorInput: AnyObject {}
 public class ListPresenter: NSObject {
     public var listInteractor : ListInteractorInput?
     public var listWireframe : ListWireframe?
@@ -96,8 +96,8 @@ public class ListWireframe : NSObject {
     }
 }
 
-public protocol AddModuleDelegate: class {}
-public protocol AddModuleInterface: class {}
+public protocol AddModuleDelegate: AnyObject {}
+public protocol AddModuleInterface: AnyObject {}
 public class AddWireframe: NSObject {
     let addPresenter : AddPresenter
     public init(addPresenter: AddPresenter) {

--- a/SampleApp/DipSampleApp/ViewControllers/FetchableTrait.swift
+++ b/SampleApp/DipSampleApp/ViewControllers/FetchableTrait.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol FetchableTrait: class {
+protocol FetchableTrait: AnyObject {
     associatedtype ObjectType
     var objects: [ObjectType]? { get set }
     var batchRequestID: Int { get set }

--- a/Sources/Definition.swift
+++ b/Sources/Definition.swift
@@ -61,7 +61,7 @@ public struct DefinitionKey: Hashable, CustomStringConvertible {
 }
 
 ///Dummy protocol to store definitions for different types in collection
-public protocol DefinitionType: class { }
+public protocol DefinitionType: AnyObject { }
 
 /**
  `Definition<T, U>` describes how instances of type `T` should be created when this type is resolved by the `DependencyContainer`.

--- a/Tests/DipTests/AutoInjectionTests.swift
+++ b/Tests/DipTests/AutoInjectionTests.swift
@@ -25,12 +25,12 @@
 import XCTest
 @testable import Dip
 
-private protocol Server: class {
+private protocol Server: AnyObject {
   var client: Client! {get}
   var anotherClient: Client! {get set}
 }
 
-private protocol Client: class {
+private protocol Client: AnyObject {
   var server: Server? {get}
   var anotherServer: Server! {get set}
 }

--- a/Tests/DipTests/AutoWiringTests.swift
+++ b/Tests/DipTests/AutoWiringTests.swift
@@ -25,12 +25,12 @@
 import XCTest
 @testable import Dip
 
-private protocol Service: class { }
+private protocol Service: AnyObject { }
 private class ServiceImp1: Service { }
 private class ServiceImp2: Service { }
 private class ServiceImp3 {}
 
-private protocol AutoWiredClient: class {
+private protocol AutoWiredClient: AnyObject {
   var service1: Service! { get set }
   var service2: Service! { get set }
 }

--- a/Tests/DipTests/ComponentScopeTests.swift
+++ b/Tests/DipTests/ComponentScopeTests.swift
@@ -25,7 +25,7 @@
 import XCTest
 @testable import Dip
 
-private protocol Service: class {}
+private protocol Service: AnyObject {}
 private class ServiceImp1: Service {}
 private class ServiceImp2: Service {}
 

--- a/Tests/DipTests/DipTests.swift
+++ b/Tests/DipTests/DipTests.swift
@@ -25,14 +25,14 @@
 import XCTest
 @testable import Dip
 
-private protocol Service: class { }
+private protocol Service: AnyObject { }
 private class ServiceImp1: Service { }
 private class ServiceImp2: Service { }
 
-private protocol Server: class {
+private protocol Server: AnyObject {
   var client: Client! { get }
 }
-private protocol Client: class {
+private protocol Client: AnyObject {
   var server: Server! { get }
 }
 

--- a/Tests/DipTests/DipUITests.swift
+++ b/Tests/DipTests/DipUITests.swift
@@ -164,10 +164,10 @@ class DipUITests: XCTestCase {
   }
 }
 
-protocol SomeService: class {
+protocol SomeService: AnyObject {
   var delegate: SomeServiceDelegate? { get set }
 }
-protocol SomeServiceDelegate: class { }
+protocol SomeServiceDelegate: AnyObject { }
 class SomeServiceImp: SomeService {
   weak var delegate: SomeServiceDelegate?
   init(delegate: SomeServiceDelegate) {
@@ -176,10 +176,10 @@ class SomeServiceImp: SomeService {
   init(){}
 }
 
-protocol OtherService: class {
+protocol OtherService: AnyObject {
   var delegate: OtherServiceDelegate? { get set }
 }
-protocol OtherServiceDelegate: class {}
+protocol OtherServiceDelegate: AnyObject {}
 class OtherServiceImp: OtherService {
   weak var delegate: OtherServiceDelegate?
   init(delegate: OtherServiceDelegate){
@@ -189,7 +189,7 @@ class OtherServiceImp: OtherService {
 }
 
 
-protocol SomeScreen: class {
+protocol SomeScreen: AnyObject {
   var someService: SomeService? { get set }
   var otherService: OtherService? { get set }
 }

--- a/Tests/DipTests/ThreadSafetyTests.swift
+++ b/Tests/DipTests/ThreadSafetyTests.swift
@@ -26,11 +26,11 @@
 import XCTest
 @testable import Dip
 
-private protocol Server: class {
+private protocol Server: AnyObject {
   var client: Client! { get set }
 }
 
-private protocol Client: class {
+private protocol Client: AnyObject {
   var server: Server { get }
 }
 

--- a/Tests/DipTests/TypeForwardingTests.swift
+++ b/Tests/DipTests/TypeForwardingTests.swift
@@ -25,8 +25,8 @@
 import XCTest
 @testable import Dip
 
-private protocol Service: class { }
-private protocol ForwardedType: class { }
+private protocol Service: AnyObject { }
+private protocol ForwardedType: AnyObject { }
 #if os(Linux)
 private class ServiceImp1: Service, ForwardedType { }
 private class ServiceImp2: Service, ForwardedType { }


### PR DESCRIPTION
Replaced occurrences of `class` with `AnyObject` in protocol conformance.