### PR TITLE
Definitions lookup with lazy operator

### DIFF
--- a/Sources/Resolve.swift
+++ b/Sources/Resolve.swift
@@ -253,7 +253,7 @@ extension DependencyContainer {
     
     //if no definition registered for exact type try to find type-forwarding definition that can resolve the type
     //that will actually happen only when resolving optionals
-    if definitions.filter({ $0.0.type == key.type }).isEmpty {
+    guard definitions.contains(where: { $0.0.type == key.type }) else {
       return typeForwardingDefinition(forKey: key)
     }
     return nil

--- a/Tests/DipTests/AutoInjectionTests.swift
+++ b/Tests/DipTests/AutoInjectionTests.swift
@@ -51,12 +51,12 @@ private class ClientImp: Client {
   
   @Injected(didInject: { _ in
     AutoInjectionTests.serverDidInjectCalled = true
-  }) var server: Server
+  }) var server: Server?
   
   @Injected(required: false) var _optionalProperty: AnyObject?
-  
-  @Injected(tag: "tagged") var taggedServer: Server
-  @Injected(tag: nil) var nilTaggedServer: Server
+    
+  @Injected(tag: "tagged") var taggedServer: Server?
+  @Injected(tag: nil) var nilTaggedServer: Server?
   
   var anotherServer: Server!
 }


### PR DESCRIPTION
I find out that optionals definitions lookup was made by combination of `filter` + `isEmpty`.
The problem with that approach is that it's iterate definitions until the end even when the target elements stored at the begin.
This behavior can be optimized using the `contains` operator.